### PR TITLE
Comet Feedback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Stellar Expert WASM Release
+on:
+  push: 
+    tags:
+      - 'v*'  # triggered whenever a new tag (previxed with "v") is pushed to the repository
+jobs:
+  release-contract-governor:
+    uses: stellar-expert/soroban-build-workflow/.github/workflows/release.yml@main
+    with:
+      release_name: ${{ github.ref_name }}
+      release_description: 'Comet Factory Release'
+      relative_path: '["factory"]'
+      package: 'factory'
+    secrets:
+      release_token: ${{ secrets.GITHUB_TOKEN }}
+
+  release-contract-votes:
+    uses: stellar-expert/soroban-build-workflow/.github/workflows/release.yml@main
+    with:
+      release_name: ${{ github.ref_name }}
+      release_description: 'Comet Pool Release'
+      relative_path: '["contracts"]'
+      package: 'contracts'
+    secrets:
+      release_token: ${{ secrets.GITHUB_TOKEN }}

--- a/contracts/src/c_pool/call_logic/pool.rs
+++ b/contracts/src/c_pool/call_logic/pool.rs
@@ -136,7 +136,7 @@ pub fn execute_swap_exact_amount_in(
         token_amount_in
             <= in_record
                 .balance
-                .fixed_mul_ceil(MAX_IN_RATIO, STROOP)
+                .fixed_mul_floor(MAX_IN_RATIO, STROOP)
                 .unwrap_optimized(),
         Error::ErrMaxInRatio
     );
@@ -234,7 +234,7 @@ pub fn execute_swap_exact_amount_out(
         token_amount_out
             <= out_record
                 .balance
-                .fixed_mul_ceil(MAX_OUT_RATIO, STROOP)
+                .fixed_mul_floor(MAX_OUT_RATIO, STROOP)
                 .unwrap_optimized(),
         Error::ErrMaxOutRatio
     );
@@ -321,7 +321,7 @@ pub fn execute_dep_tokn_amt_in_get_lp_tokns_out(
         token_amount_in
             <= in_record
                 .balance
-                .fixed_mul_ceil(MAX_IN_RATIO, STROOP)
+                .fixed_mul_floor(MAX_IN_RATIO, STROOP)
                 .unwrap_optimized(),
         Error::ErrMaxInRatio
     );
@@ -392,7 +392,7 @@ pub fn execute_dep_lp_tokn_amt_out_get_tokn_in(
         token_amount_in
             <= in_record
                 .balance
-                .fixed_mul_ceil(MAX_IN_RATIO, STROOP)
+                .fixed_mul_floor(MAX_IN_RATIO, STROOP)
                 .unwrap_optimized(),
         Error::ErrMaxInRatio
     );
@@ -447,9 +447,9 @@ pub fn execute_wdr_tokn_amt_in_get_lp_tokns_out(
         token_amount_out
             <= out_record
                 .balance
-                .fixed_mul_ceil(MAX_OUT_RATIO, STROOP)
+                .fixed_mul_floor(MAX_OUT_RATIO, STROOP)
                 .unwrap_optimized(),
-        Error::ErrMaxInRatio
+        Error::ErrMaxOutRatio
     );
     assert_with_error!(
         &e,
@@ -495,7 +495,7 @@ pub fn execute_wdr_tokn_amt_out_get_lp_tokns_in(
         token_amount_out
             <= out_record
                 .balance
-                .fixed_mul_ceil(MAX_OUT_RATIO, STROOP)
+                .fixed_mul_floor(MAX_OUT_RATIO, STROOP)
                 .unwrap_optimized(),
         Error::ErrMaxOutRatio
     );

--- a/contracts/src/c_pool/call_logic/pool.rs
+++ b/contracts/src/c_pool/call_logic/pool.rs
@@ -119,7 +119,7 @@ pub fn execute_swap_exact_amount_in(
     user: Address,
 ) -> (i128, i128) {
     assert_with_error!(&e, !read_freeze(&e), Error::ErrFreezeOnlyWithdrawals);
-    assert_with_error!(&e, token_amount_in >= 0, Error::ErrNegative);
+    assert_with_error!(&e, token_amount_in > 0, Error::ErrNegativeOrZero);
     assert_with_error!(&e, min_amount_out >= 0, Error::ErrNegative);
     assert_with_error!(&e, max_price >= 0, Error::ErrNegative);
 
@@ -217,8 +217,8 @@ pub fn execute_swap_exact_amount_out(
     user: Address,
 ) -> (i128, i128) {
     assert_with_error!(&e, !read_freeze(&e), Error::ErrFreezeOnlyWithdrawals);
-    assert_with_error!(&e, token_amount_out >= 0, Error::ErrNegative);
-    assert_with_error!(&e, max_amount_in >= 0, Error::ErrNegative);
+    assert_with_error!(&e, token_amount_out > 0, Error::ErrNegativeOrZero);
+    assert_with_error!(&e, max_amount_in > 0, Error::ErrNegativeOrZero);
     assert_with_error!(&e, max_price >= 0, Error::ErrNegative);
 
     let swap_fee = read_swap_fee(&e);

--- a/contracts/src/tests/c_pool_single_sided.rs
+++ b/contracts/src/tests/c_pool_single_sided.rs
@@ -288,12 +288,12 @@ fn test_single_sided_wdr() {
     let bal_token_out_fixed = bal_token_out.to_i128(&7);
     let under_out = bal_token_out_fixed - 1000;
 
-    // verify MAX_IN_RATIO
+    // verify MAX_OUT_RATIO
     let result = comet.try_wdr_tokn_amt_in_get_lp_tokns_out(&token_1, &99_9999999, &0, &admin);
     assert_eq!(
         result.err(),
         Some(Ok(Error::from_contract_error(
-            CometError::ErrMaxInRatio as u32
+            CometError::ErrMaxOutRatio as u32
         )))
     );
 

--- a/contracts/src/tests/c_pool_swap.rs
+++ b/contracts/src/tests/c_pool_swap.rs
@@ -69,7 +69,16 @@ fn test_swap_out_given_in() {
     assert_eq!(
         result.err(),
         Some(Ok(Error::from_contract_error(
-            CometError::ErrNegative as u32
+            CometError::ErrNegativeOrZero as u32
+        )))
+    );
+
+    // verify zero input
+    let result = comet.try_swap_exact_amount_in(&token_1, &0, &token_2, &0, &i128::MAX, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrNegativeOrZero as u32
         )))
     );
 
@@ -228,7 +237,24 @@ fn test_swap_in_given_out() {
     assert_eq!(
         result.err(),
         Some(Ok(Error::from_contract_error(
-            CometError::ErrNegative as u32
+            CometError::ErrNegativeOrZero as u32
+        )))
+    );
+
+    // verify zero input
+    let result =
+        comet.try_swap_exact_amount_out(&token_2, &i128::MAX, &token_1, &0, &i128::MAX, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrNegativeOrZero as u32
+        )))
+    );
+    let result = comet.try_swap_exact_amount_out(&token_2, &0, &token_1, &1, &i128::MAX, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrNegativeOrZero as u32
         )))
     );
 


### PR DESCRIPTION
Fixes the following feedback relating to the recent set of changes:

1. [token_amount_in](https://github.com/mootz12/comet-contracts-v1/blob/main/contracts/src/c_pool/call_logic/pool.rs#L122), [token_amount_out and max_amount_in](https://github.com/mootz12/comet-contracts-v1/blob/main/contracts/src/c_pool/call_logic/pool.rs#L220-L221) should be strictly > 0.
2. All the MaxInRatio/MaxOutRatio assertions should use fixed_mul_floor instead in [pool implementation](https://github.com/mootz12/comet-contracts-v1/blob/main/contracts/src/c_pool/call_logic/pool.rs).
3. [This error code](https://github.com/mootz12/comet-contracts-v1/blob/main/contracts/src/c_pool/call_logic/pool.rs#L452) should be ErrMaxOutRatio instead.