### PR TITLE
fix: reject same-token swaps

### DIFF
--- a/contracts/src/c_pool/call_logic/getter.rs
+++ b/contracts/src/c_pool/call_logic/getter.rs
@@ -1,12 +1,16 @@
-use soroban_sdk::{unwrap::UnwrapOptimized, Address, Env};
+use soroban_sdk::{assert_with_error, unwrap::UnwrapOptimized, Address, Env};
 
 use crate::{
     c_math::calc_spot_price,
-    c_pool::metadata::{read_record, read_swap_fee},
+    c_pool::{
+        error::Error,
+        metadata::{read_record, read_swap_fee},
+    },
 };
 
 // Calculate the spot considering the swap fee
 pub fn execute_get_spot_price(e: Env, token_in: Address, token_out: Address) -> i128 {
+    assert_with_error!(&e, token_in != token_out, Error::ErrSameToken);
     let record = read_record(&e);
     let in_record = record.get(token_in).unwrap_optimized();
     let out_record = record.get(token_out).unwrap_optimized();
@@ -16,6 +20,7 @@ pub fn execute_get_spot_price(e: Env, token_in: Address, token_out: Address) -> 
 
 // Get the spot price without considering the swap fee
 pub fn execute_get_spot_price_sans_fee(e: Env, token_in: Address, token_out: Address) -> i128 {
+    assert_with_error!(&e, token_in != token_out, Error::ErrSameToken);
     let record = read_record(&e);
     let in_record = record.get(token_in).unwrap_optimized();
     let out_record = record.get(token_out).unwrap_optimized();

--- a/contracts/src/c_pool/call_logic/pool.rs
+++ b/contracts/src/c_pool/call_logic/pool.rs
@@ -119,6 +119,7 @@ pub fn execute_swap_exact_amount_in(
     user: Address,
 ) -> (i128, i128) {
     assert_with_error!(&e, !read_freeze(&e), Error::ErrFreezeOnlyWithdrawals);
+    assert_with_error!(&e, token_in != token_out, Error::ErrSameToken);
     assert_with_error!(&e, token_amount_in > 0, Error::ErrNegativeOrZero);
     assert_with_error!(&e, min_amount_out >= 0, Error::ErrNegative);
     assert_with_error!(&e, max_price >= 0, Error::ErrNegative);
@@ -217,6 +218,7 @@ pub fn execute_swap_exact_amount_out(
     user: Address,
 ) -> (i128, i128) {
     assert_with_error!(&e, !read_freeze(&e), Error::ErrFreezeOnlyWithdrawals);
+    assert_with_error!(&e, token_in != token_out, Error::ErrSameToken);
     assert_with_error!(&e, token_amount_out > 0, Error::ErrNegativeOrZero);
     assert_with_error!(&e, max_amount_in > 0, Error::ErrNegativeOrZero);
     assert_with_error!(&e, max_price >= 0, Error::ErrNegative);

--- a/contracts/src/c_pool/error.rs
+++ b/contracts/src/c_pool/error.rs
@@ -42,4 +42,5 @@ pub enum Error {
     ErrInvalidExpirationLedger = 36,
     ErrNegativeOrZero = 37,
     ErrTokenInvalid = 38,
+    ErrSameToken = 39,
 }

--- a/contracts/src/tests/c_pool_swap.rs
+++ b/contracts/src/tests/c_pool_swap.rs
@@ -22,6 +22,95 @@ use super::{
 };
 
 #[test]
+fn test_swap_exact_amount_in_rejects_same_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token_1 = create_stellar_token(&env, &admin);
+    let token_2 = create_stellar_token(&env, &admin);
+    let token_1_client = MockTokenClient::new(&env, &token_1);
+    let token_2_client = MockTokenClient::new(&env, &token_2);
+    let balances: Vec<i128> = vec![&env, 100 * STROOP, 75 * STROOP];
+    let weights: Vec<i128> = vec![&env, 5 * STROOP / 10, 5 * STROOP / 10];
+    token_1_client.mint(&admin, &balances.get_unchecked(0));
+    token_2_client.mint(&admin, &balances.get_unchecked(1));
+    token_1_client.mint(&user, &(10 * STROOP));
+
+    let comet_id = create_comet_pool(
+        &env,
+        &admin,
+        &vec![&env, token_1.clone(), token_2],
+        &weights,
+        &balances,
+        0_0030000,
+    );
+    let comet = CometPoolContractClient::new(&env, &comet_id);
+    let record_balance_before = comet.get_balance(&token_1);
+    let contract_balance_before = token_1_client.balance(&comet_id);
+    let user_balance_before = token_1_client.balance(&user);
+
+    let result = comet.try_swap_exact_amount_in(&token_1, &STROOP, &token_1, &0, &i128::MAX, &user);
+
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrSameToken as u32
+        )))
+    );
+    assert_eq!(comet.get_balance(&token_1), record_balance_before);
+    assert_eq!(token_1_client.balance(&comet_id), contract_balance_before);
+    assert_eq!(token_1_client.balance(&user), user_balance_before);
+}
+
+#[test]
+fn test_swap_exact_amount_out_rejects_same_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token_1 = create_stellar_token(&env, &admin);
+    let token_2 = create_stellar_token(&env, &admin);
+    let token_1_client = MockTokenClient::new(&env, &token_1);
+    let token_2_client = MockTokenClient::new(&env, &token_2);
+    let balances: Vec<i128> = vec![&env, 100 * STROOP, 75 * STROOP];
+    let weights: Vec<i128> = vec![&env, 5 * STROOP / 10, 5 * STROOP / 10];
+    token_1_client.mint(&admin, &balances.get_unchecked(0));
+    token_2_client.mint(&admin, &balances.get_unchecked(1));
+    token_1_client.mint(&user, &(10 * STROOP));
+
+    let comet_id = create_comet_pool(
+        &env,
+        &admin,
+        &vec![&env, token_1.clone(), token_2],
+        &weights,
+        &balances,
+        0_0030000,
+    );
+    let comet = CometPoolContractClient::new(&env, &comet_id);
+    let record_balance_before = comet.get_balance(&token_1);
+    let contract_balance_before = token_1_client.balance(&comet_id);
+    let user_balance_before = token_1_client.balance(&user);
+
+    let result =
+        comet.try_swap_exact_amount_out(&token_1, &i128::MAX, &token_1, &STROOP, &i128::MAX, &user);
+
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrSameToken as u32
+        )))
+    );
+    assert_eq!(comet.get_balance(&token_1), record_balance_before);
+    assert_eq!(token_1_client.balance(&comet_id), contract_balance_before);
+    assert_eq!(token_1_client.balance(&user), user_balance_before);
+}
+
+#[test]
 fn test_swap_out_given_in() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/src/tests/c_pool_swap.rs
+++ b/contracts/src/tests/c_pool_swap.rs
@@ -111,6 +111,42 @@ fn test_swap_exact_amount_out_rejects_same_token() {
 }
 
 #[test]
+fn test_spot_price_getters_reject_same_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let admin = Address::generate(&env);
+    let token_1 = create_stellar_token(&env, &admin);
+    let token_2 = create_stellar_token(&env, &admin);
+    let token_1_client = MockTokenClient::new(&env, &token_1);
+    let token_2_client = MockTokenClient::new(&env, &token_2);
+    let balances: Vec<i128> = vec![&env, 100 * STROOP, 75 * STROOP];
+    let weights: Vec<i128> = vec![&env, 5 * STROOP / 10, 5 * STROOP / 10];
+    token_1_client.mint(&admin, &balances.get_unchecked(0));
+    token_2_client.mint(&admin, &balances.get_unchecked(1));
+
+    let comet_id = create_comet_pool(
+        &env,
+        &admin,
+        &vec![&env, token_1.clone(), token_2],
+        &weights,
+        &balances,
+        0_0030000,
+    );
+    let comet = CometPoolContractClient::new(&env, &comet_id);
+
+    let with_fee = comet.try_get_spot_price(&token_1, &token_1);
+    let sans_fee = comet.try_get_spot_price_sans_fee(&token_1, &token_1);
+    let expected_error = Some(Ok(Error::from_contract_error(
+        CometError::ErrSameToken as u32,
+    )));
+
+    assert_eq!(with_fee.err(), expected_error);
+    assert_eq!(sans_fee.err(), expected_error);
+}
+
+#[test]
 fn test_swap_out_given_in() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
- Reject swaps where `token_in == token_out`
- Apply the validation to both `swap_exact_amount_in` and `swap_exact_amount_out`
- Add `ErrSameToken = 39` without changing existing error codes
- Add regression tests covering both swap paths

## Background
Both swap functions load the input and output reserve records independently.

When `token_in` and `token_out` are the same address, both records originate from the same map entry. The records are then mutated independently, and the second `Map::set` overwrites the first under the shared key. This can cause the
pool's recorded reserve to diverge from its actual token balance.

## Fix
Validate that the input and output token addresses differ before reading or mutating reserve records, calculating swap amounts, or transferring tokens.

Same-token swaps now fail with `ErrSameToken`.

## Testing
Regression tests verify that rejected same-token swaps leave all of the following unchanged:
- The pool's recorded reserve
- The token balance held by the pool contract
- The user's token balance