### PR TITLE
Reject inexact underlying token transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Smart Contracts explicitly written for Soroban.
 
 ```cargo build --target wasm32-unknown-unknown --release```
 
+## Security Assumptions
+
+Comet pools require trusted SEP-41 token contracts whose transfers debit the sender and credit the recipient by exactly the requested amount. Pool operations verify both observed balance changes and reject transfer fees, in-call rebases, and other mismatches atomically. These checks cannot establish that an actively malicious token contract is trustworthy because the token contract controls its reported balances.
+
+Factory registration identifies a pool created through the factory; it does not endorse the pool's tokens. Integrations must independently allowlist the token contracts and pools they trust.
+
 ## Best Practices Used
 
 1. All Rust code is linted with Clippy with the command `cargo clippy`.

--- a/contracts/src/c_pool/call_logic/init.rs
+++ b/contracts/src/c_pool/call_logic/init.rs
@@ -9,7 +9,7 @@ use crate::{
         error::Error,
         metadata::{write_controller, write_metadata, write_record, write_swap_fee, write_tokens},
         storage_types::{DataKey, Record},
-        token_utility::mint_shares,
+        token_utility::{mint_shares, transfer_underlying},
     },
 };
 
@@ -62,7 +62,13 @@ pub fn execute_init(
         total_weight += weight;
 
         // transfer starting balance to the pool
-        token_client.transfer(&controller, &e.current_contract_address(), &balance);
+        transfer_underlying(
+            e,
+            &token,
+            &controller,
+            &e.current_contract_address(),
+            balance,
+        );
 
         let record = Record {
             balance,

--- a/contracts/src/c_pool/error.rs
+++ b/contracts/src/c_pool/error.rs
@@ -42,4 +42,5 @@ pub enum Error {
     ErrInvalidExpirationLedger = 36,
     ErrNegativeOrZero = 37,
     ErrTokenInvalid = 38,
+    ErrBalanceMismatch = 39,
 }

--- a/contracts/src/c_pool/token_utility.rs
+++ b/contracts/src/c_pool/token_utility.rs
@@ -1,30 +1,60 @@
 //! Utilities for the LP Token
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{assert_with_error, Address, Env};
 use soroban_token_sdk::TokenUtils;
 
 use super::{
     balance::{receive_balance, spend_balance},
+    error::Error,
     metadata::{get_total_shares, put_total_shares},
 };
 
 use soroban_sdk::token::Client;
 
+fn transfer_balances(e: &Env, client: &Client, from: &Address, to: &Address) -> (i128, i128) {
+    assert_with_error!(e, from != to, Error::ErrBalanceMismatch);
+    (client.balance(from), client.balance(to))
+}
+
+fn require_exact_transfer(
+    e: &Env,
+    client: &Client,
+    from: &Address,
+    to: &Address,
+    amount: i128,
+    balances_before: (i128, i128),
+) {
+    let expected_from = balances_before.0.checked_sub(amount);
+    let expected_to = balances_before.1.checked_add(amount);
+    assert_with_error!(
+        e,
+        expected_from == Some(client.balance(from)) && expected_to == Some(client.balance(to)),
+        Error::ErrBalanceMismatch
+    );
+}
+
+/// Transfer an exact amount between two addresses.
+pub fn transfer_underlying(e: &Env, token: &Address, from: &Address, to: &Address, amount: i128) {
+    let client = Client::new(e, token);
+    let balances_before = transfer_balances(e, &client, from, to);
+    client.transfer(from, to, &amount);
+    require_exact_transfer(e, &client, from, to, amount, balances_before);
+}
+
 // Transfers the Specific Token from the User’s Address to the Contract’s Address
 pub fn pull_underlying(e: &Env, token: &Address, from: &Address, amount: i128, max_amount: i128) {
     // @DEV - This rounds the sequence number to the nearest 100000 to avoid simulation -> execution sequence number mismatch
     let ledger = (e.ledger().sequence() / 100000 + 1) * 100000;
-    Client::new(e, token).approve(&from, &e.current_contract_address(), &max_amount, &ledger);
-    Client::new(e, token).transfer_from(
-        &e.current_contract_address(),
-        &from,
-        &e.current_contract_address(),
-        &amount,
-    );
+    let client = Client::new(e, token);
+    let contract = e.current_contract_address();
+    client.approve(from, &contract, &max_amount, &ledger);
+    let balances_before = transfer_balances(e, &client, from, &contract);
+    client.transfer_from(&contract, from, &contract, &amount);
+    require_exact_transfer(e, &client, from, &contract, amount, balances_before);
 }
 
 // Transfers the Specific Token from the Contract’s Address to the given 'to' Address
 pub fn push_underlying(e: &Env, token: &Address, to: &Address, amount: i128) {
-    Client::new(e, token).transfer(&e.current_contract_address(), &to, &amount);
+    transfer_underlying(e, token, &e.current_contract_address(), to, amount);
 }
 
 // Mint the given amount of LP Tokens

--- a/contracts/src/tests/c_pool_token_behavior.rs
+++ b/contracts/src/tests/c_pool_token_behavior.rs
@@ -1,0 +1,208 @@
+#![cfg(test)]
+
+use sep_41_token::testutils::MockTokenClient;
+use soroban_sdk::{
+    contract, contractimpl, contracttype, testutils::Address as _, vec, Address, Env, Error, String,
+};
+
+use crate::{
+    c_consts::STROOP,
+    c_pool::{
+        comet::{CometPoolContract, CometPoolContractClient},
+        error::Error as CometError,
+    },
+};
+
+#[derive(Clone)]
+#[contracttype]
+enum FeeTokenKey {
+    Balance(Address),
+    Fee,
+}
+
+#[contract]
+struct FeeToken;
+
+#[contractimpl]
+impl FeeToken {
+    pub fn init(e: Env) {
+        e.storage().instance().set(&FeeTokenKey::Fee, &0i128);
+    }
+
+    pub fn mint(e: Env, to: Address, amount: i128) {
+        write_balance(&e, &to, read_balance(&e, &to) + amount);
+    }
+
+    pub fn set_fee(e: Env, fee: i128) {
+        e.storage().instance().set(&FeeTokenKey::Fee, &fee);
+    }
+
+    pub fn approve(
+        _e: Env,
+        _from: Address,
+        _spender: Address,
+        _amount: i128,
+        _expiration_ledger: u32,
+    ) {
+    }
+
+    pub fn balance(e: Env, id: Address) -> i128 {
+        read_balance(&e, &id)
+    }
+
+    pub fn transfer(e: Env, from: Address, to: Address, amount: i128) {
+        transfer(&e, &from, &to, amount);
+    }
+
+    pub fn transfer_from(e: Env, _spender: Address, from: Address, to: Address, amount: i128) {
+        transfer(&e, &from, &to, amount);
+    }
+
+    pub fn decimals(_e: Env) -> u32 {
+        7
+    }
+
+    pub fn name(e: Env) -> String {
+        String::from_str(&e, "Fee Token")
+    }
+
+    pub fn symbol(e: Env) -> String {
+        String::from_str(&e, "FEE")
+    }
+}
+
+fn read_balance(e: &Env, address: &Address) -> i128 {
+    e.storage()
+        .instance()
+        .get(&FeeTokenKey::Balance(address.clone()))
+        .unwrap_or(0)
+}
+
+fn write_balance(e: &Env, address: &Address, amount: i128) {
+    e.storage()
+        .instance()
+        .set(&FeeTokenKey::Balance(address.clone()), &amount);
+}
+
+fn transfer(e: &Env, from: &Address, to: &Address, amount: i128) {
+    let fee = e
+        .storage()
+        .instance()
+        .get(&FeeTokenKey::Fee)
+        .unwrap_or(0i128);
+    write_balance(e, from, read_balance(e, from) - amount);
+    write_balance(e, to, read_balance(e, to) + amount - fee);
+}
+
+fn register_fee_token(e: &Env) -> Address {
+    let token = e.register_contract(None, FeeToken);
+    FeeTokenClient::new(e, &token).init();
+    token
+}
+
+fn assert_balance_mismatch<T, E>(result: Result<T, Result<Error, E>>) {
+    assert_eq!(
+        result.err().map(|error| error.map_err(|_| ())),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrBalanceMismatch as u32
+        )))
+    );
+}
+
+#[test]
+fn init_rejects_inexact_token_transfer_and_rolls_back() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let controller = Address::generate(&e);
+    let standard_token = e.register_stellar_asset_contract(controller.clone());
+    let standard_client = MockTokenClient::new(&e, &standard_token);
+    let fee_token = register_fee_token(&e);
+    let fee_client = FeeTokenClient::new(&e, &fee_token);
+
+    standard_client.mint(&controller, &STROOP);
+    fee_client.mint(&controller, &STROOP);
+    fee_client.set_fee(&1);
+
+    let pool = e.register_contract(None, CometPoolContract);
+    let client = CometPoolContractClient::new(&e, &pool);
+    let result = client.try_init(
+        &controller,
+        &vec![&e, standard_token.clone(), fee_token.clone()],
+        &vec![&e, STROOP / 2, STROOP / 2],
+        &vec![&e, STROOP, STROOP],
+        &0_0030000,
+    );
+
+    assert_balance_mismatch(result);
+    assert_eq!(standard_client.balance(&controller), STROOP);
+    assert_eq!(standard_client.balance(&pool), 0);
+    assert_eq!(fee_client.balance(&controller), STROOP);
+    assert_eq!(fee_client.balance(&pool), 0);
+}
+
+#[test]
+fn swaps_reject_inexact_input_and_output_transfers_and_roll_back() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.budget().reset_unlimited();
+
+    let controller = Address::generate(&e);
+    let user = Address::generate(&e);
+    let standard_token = e.register_stellar_asset_contract(controller.clone());
+    let standard_client = MockTokenClient::new(&e, &standard_token);
+    let fee_token = register_fee_token(&e);
+    let fee_client = FeeTokenClient::new(&e, &fee_token);
+    let reserve = 100 * STROOP;
+    let user_balance = 10 * STROOP;
+
+    standard_client.mint(&controller, &reserve);
+    standard_client.mint(&user, &user_balance);
+    fee_client.mint(&controller, &reserve);
+    fee_client.mint(&user, &user_balance);
+
+    let pool = e.register_contract(None, CometPoolContract);
+    let client = CometPoolContractClient::new(&e, &pool);
+    client.init(
+        &controller,
+        &vec![&e, standard_token.clone(), fee_token.clone()],
+        &vec![&e, STROOP / 2, STROOP / 2],
+        &vec![&e, reserve, reserve],
+        &0_0030000,
+    );
+    fee_client.set_fee(&1);
+
+    let result = client.try_swap_exact_amount_in(
+        &fee_token,
+        &STROOP,
+        &standard_token,
+        &0,
+        &i128::MAX,
+        &user,
+    );
+    assert_balance_mismatch(result);
+
+    assert_eq!(fee_client.balance(&user), user_balance);
+    assert_eq!(fee_client.balance(&pool), reserve);
+    assert_eq!(standard_client.balance(&user), user_balance);
+    assert_eq!(standard_client.balance(&pool), reserve);
+    assert_eq!(client.get_balance(&fee_token), reserve);
+    assert_eq!(client.get_balance(&standard_token), reserve);
+
+    let result = client.try_swap_exact_amount_in(
+        &standard_token,
+        &STROOP,
+        &fee_token,
+        &0,
+        &i128::MAX,
+        &user,
+    );
+    assert_balance_mismatch(result);
+
+    assert_eq!(fee_client.balance(&user), user_balance);
+    assert_eq!(fee_client.balance(&pool), reserve);
+    assert_eq!(standard_client.balance(&user), user_balance);
+    assert_eq!(standard_client.balance(&pool), reserve);
+    assert_eq!(client.get_balance(&fee_token), reserve);
+    assert_eq!(client.get_balance(&standard_token), reserve);
+}

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -9,3 +9,4 @@ pub mod c_pool_join_exit;
 pub mod c_pool_single_sided;
 pub mod c_pool_swap;
 pub mod c_pool_test;
+pub mod c_pool_token_behavior;

--- a/factory/src/test.rs
+++ b/factory/src/test.rs
@@ -3,11 +3,68 @@
 extern crate std;
 
 use crate::{Factory, FactoryClient};
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, vec, Address, BytesN, Env};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::Address as _,
+    token::{StellarAssetClient, TokenClient},
+    vec, Address, BytesN, Env, Error,
+};
 
 // The contract that will be deployed by the deployer contract.
 mod contract {
     soroban_sdk::contractimport!(file = "../target/wasm32-unknown-unknown/optimized/comet.wasm");
+}
+
+#[derive(Clone)]
+#[contracttype]
+enum FeeTokenKey {
+    Balance(Address),
+    Fee,
+}
+
+#[contract]
+struct FeeToken;
+
+#[contractimpl]
+impl FeeToken {
+    pub fn mint(e: Env, to: Address, amount: i128) {
+        write_balance(&e, &to, read_balance(&e, &to) + amount);
+    }
+
+    pub fn set_fee(e: Env, fee: i128) {
+        e.storage().instance().set(&FeeTokenKey::Fee, &fee);
+    }
+
+    pub fn balance(e: Env, id: Address) -> i128 {
+        read_balance(&e, &id)
+    }
+
+    pub fn transfer(e: Env, from: Address, to: Address, amount: i128) {
+        let fee = e
+            .storage()
+            .instance()
+            .get(&FeeTokenKey::Fee)
+            .unwrap_or(0i128);
+        write_balance(&e, &from, read_balance(&e, &from) - amount);
+        write_balance(&e, &to, read_balance(&e, &to) + amount - fee);
+    }
+
+    pub fn decimals(_e: Env) -> u32 {
+        7
+    }
+}
+
+fn read_balance(e: &Env, address: &Address) -> i128 {
+    e.storage()
+        .instance()
+        .get(&FeeTokenKey::Balance(address.clone()))
+        .unwrap_or(0)
+}
+
+fn write_balance(e: &Env, address: &Address, amount: i128) {
+    e.storage()
+        .instance()
+        .set(&FeeTokenKey::Balance(address.clone()), &amount);
 }
 
 #[test]
@@ -44,4 +101,42 @@ fn test_factory() {
     assert_eq!(pool_client.get_tokens(), tokens);
     assert_eq!(pool_client.get_swap_fee(), swap_fee);
     assert_eq!(pool_client.get_total_supply(), 100 * 1_0000000);
+}
+
+#[test]
+fn test_compiled_pool_rejects_inexact_initial_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let controller = Address::generate(&env);
+    let standard_token = env.register_stellar_asset_contract(controller.clone());
+    let standard_client = StellarAssetClient::new(&env, &standard_token);
+    let standard_token_client = TokenClient::new(&env, &standard_token);
+    let fee_token = env.register_contract(None, FeeToken);
+    let fee_client = FeeTokenClient::new(&env, &fee_token);
+    standard_client.mint(&controller, &1_0000000);
+    fee_client.mint(&controller, &1_0000000);
+    fee_client.set_fee(&1);
+
+    let pool = env.register_contract_wasm(None, contract::WASM);
+    let pool_client = contract::Client::new(&env, &pool);
+    let result = pool_client.try_init(
+        &controller,
+        &vec![&env, standard_token.clone(), fee_token.clone()],
+        &vec![&env, 0_5000000, 0_5000000],
+        &vec![&env, 1_0000000, 1_0000000],
+        &0_0030000,
+    );
+
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            contract::Error::ErrBalanceMismatch as u32
+        )))
+    );
+    assert_eq!(standard_token_client.balance(&controller), 1_0000000);
+    assert_eq!(standard_token_client.balance(&pool), 0);
+    assert_eq!(fee_client.balance(&controller), 1_0000000);
+    assert_eq!(fee_client.balance(&pool), 0);
 }


### PR DESCRIPTION
## Summary

- Verify that every underlying-token transfer debits the sender and credits the recipient by exactly the requested amount.
- Apply the same validation during pool initialization, joins, exits, swaps, and single-sided liquidity operations.
- Add `ErrBalanceMismatch` and native plus optimized-WASM regression coverage for inexact transfers and atomic rollback.
- Document the requirement for trusted SEP-41 tokens and independent integration allowlisting.

## Security impact

Previously, Comet updated its internal reserve records using requested transfer amounts without verifying the balances actually moved by the underlying token contract. Fee-on-transfer tokens, in-call rebases, or other nonstandard behavior could therefore make recorded reserves or user receipts diverge from actual balances. A mismatch now fails with `ErrBalanceMismatch` and rolls back the complete operation atomically.

These checks are defense-in-depth and do not make an actively malicious token trustworthy because the token contract controls its reported balances. Factory registration identifies how a pool was created but does not endorse its tokens, so integrations must continue to allowlist trusted tokens and pools independently.

## Compatibility

Standard SEP-41 tokens with exact transfer semantics are unaffected. Tokens that charge transfer fees, rebase during a transfer, or otherwise report unexpected sender or recipient balance changes are now rejected. The new error is appended as contract error code 39 without changing existing error codes or public function signatures.

## Testing

- `cargo fmt --all -- --check`
- `cargo +1.78.0 build --locked --target wasm32-unknown-unknown --release --workspace`
- `stellar contract optimize --wasm target/wasm32-unknown-unknown/release/contracts.wasm --wasm-out target/wasm32-unknown-unknown/optimized/comet.wasm`
- `cargo +1.78.0 test --locked --workspace --all-targets`

All 24 workspace tests pass, including the optimized-WASM regression. The optimized Comet WASM is 29,476 bytes, an increase of 432 bytes from the 29,044-byte baseline. Clippy was not run because the component is not installed for the Rust 1.78 toolchain.