### PR TITLE
Harden the release workflow against mutable dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,105 @@
 name: Stellar Expert WASM Release
-on:
-  push: 
-    tags:
-      - 'v*'  # triggered whenever a new tag (previxed with "v") is pushed to the repository
-jobs:
-  release-contract-governor:
-    uses: stellar-expert/soroban-build-workflow/.github/workflows/release.yml@main
-    with:
-      release_name: ${{ github.ref_name }}
-      release_description: 'Comet Factory Release'
-      package: 'factory'
-    secrets:
-      release_token: ${{ secrets.GITHUB_TOKEN }}
 
-  release-contract-votes:
-    uses: stellar-expert/soroban-build-workflow/.github/workflows/release.yml@main
-    with:
-      release_name: ${{ github.ref_name }}
-      release_description: 'Comet Pool Release'
-      package: 'contracts'
-    secrets:
-      release_token: ${{ secrets.GITHUB_TOKEN }}
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions: {}
+
+jobs:
+  release:
+    name: Release ${{ matrix.package }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: factory
+            description: Comet Factory Release
+          - package: contracts
+            description: Comet Pool Release
+
+    steps:
+      - name: Checkout source
+        # actions/checkout v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Build optimized WASM
+        working-directory: source
+        env:
+          PACKAGE: ${{ matrix.package }}
+          # Workflow release v20.3.11, containing Soroban CLI 20.3.1 and Rust 1.77.2.
+          # Before updating, audit the upstream source, resolve the new amd64 digest, and reproduce both release artifacts.
+          BUILD_IMAGE: ghcr.io/stellar-expert/soroban-build-workflow:v20.3.11@sha256:639a1950cdd31a7fd86b75a5dd5d946ec862344ffe9730e38bd2a094b607e4ec
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --env PACKAGE \
+            --volume "$PWD:/inspector/home" \
+            "$BUILD_IMAGE"
+
+      - name: Verify release artifact
+        id: artifact
+        working-directory: source
+        env:
+          EXPECTED_PACKAGE: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          release_dir="$PWD/compilation_workflow_release"
+          cargo_metadata="$(cargo metadata --locked --format-version 1 --no-deps)"
+          package_version="$(jq -er --arg package "$EXPECTED_PACKAGE" '.packages[] | select(.name == $package) | .version' <<< "$cargo_metadata")"
+          wasm_file="${EXPECTED_PACKAGE}_v${package_version}.wasm"
+          wasm_path="$release_dir/$wasm_file"
+          test -f "$wasm_path"
+
+          wasm_count="$(find "$release_dir" -maxdepth 1 -type f -name '*.wasm' | wc -l | tr -d ' ')"
+          test "$wasm_count" = 1
+          actual_hash="$(sha256sum "$wasm_path" | cut -d ' ' -f 1)"
+
+          {
+            echo "file=$wasm_file"
+            echo "path=$wasm_path"
+            echo "hash=$actual_hash"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_DESCRIPTION: ${{ matrix.description }}
+          WASM_FILE: ${{ steps.artifact.outputs.file }}
+          WASM_PATH: ${{ steps.artifact.outputs.path }}
+        run: |
+          set -euo pipefail
+          release_tag="${GITHUB_REF_NAME}_${WASM_FILE}"
+          gh release create "$release_tag" "$WASM_PATH" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$release_tag" \
+            --notes "$RELEASE_DESCRIPTION"
+
+      - name: Send release information to Stellar Expert
+        env:
+          CONTRACT_HASH: ${{ steps.artifact.outputs.hash }}
+          PACKAGE_NAME: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          payload="$(jq -n \
+            --arg repository "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+            --arg commitHash "$GITHUB_SHA" \
+            --arg jobId "$GITHUB_JOB" \
+            --arg runId "$GITHUB_RUN_ID" \
+            --arg contractHash "$CONTRACT_HASH" \
+            --arg packageName "$PACKAGE_NAME" \
+            '{repository: $repository, commitHash: $commitHash, jobId: $jobId, runId: $runId, contractHash: $contractHash, packageName: $packageName}')"
+          curl --fail-with-body --silent --show-error \
+            --max-time 15 \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            https://api.stellar.expert/explorer/public/contract-validation/match


### PR DESCRIPTION
## Summary

- Replace the mutable `stellar-expert/soroban-build-workflow@main` reusable workflow with explicit local release steps.
- Pin `actions/checkout` to an exact commit and the historical Stellar Expert build image to an immutable digest.
- Preserve the existing Soroban 20 build environment, artifact names, release tags, and Stellar Expert validation submission.
- Restrict workflow permissions and expose `GITHUB_TOKEN` only to the GitHub release step.
- Verify that each build produces exactly one correctly named WASM artifact and calculate its SHA-256 hash before publishing it.

## Motivation

The previous release jobs executed a third-party reusable workflow from its mutable `main` branch while passing it a write-capable repository token. A change to that upstream branch could therefore alter the code executed during a tagged release. Pinning every external executable dependency and keeping the release token out of the build environment makes tagged releases reproducible and reduces their supply-chain risk.

## Validation

- `actionlint` and ShellCheck pass for the updated workflow.
- `git diff --cached --check` passes.
- The pinned image reproduced the official `contracts_v1.0.0.wasm` artifact byte-for-byte with SHA-256 `8abc28913035c07411ed5d134e6bfeab4723d97ddd4d1a22a0605d35c94d1a36`.
- The pinned image reproduced the official `factory_v1.0.0.wasm` artifact byte-for-byte with SHA-256 `bf7adb09076853eb3aa569278754111d86e161e35e7dc6a984ecde2b9d6700ae`.
- No live tag or GitHub release was created during testing.