### PR TITLE
Validate join and exit limit vector lengths

### DIFF
--- a/contracts/src/c_pool/call_logic/pool.rs
+++ b/contracts/src/c_pool/call_logic/pool.rs
@@ -36,12 +36,18 @@ pub fn execute_join_pool(e: Env, pool_amount_out: i128, max_amounts_in: Vec<i128
     assert_with_error!(&e, !read_freeze(&e), Error::ErrFreezeOnlyWithdrawals);
     assert_with_error!(&e, pool_amount_out > 0, Error::ErrNegativeOrZero);
 
+    let tokens = read_tokens(&e);
+    assert_with_error!(
+        &e,
+        max_amounts_in.len() == tokens.len(),
+        Error::ErrInvalidVectorLen
+    );
+
     let pool_total = get_total_shares(&e);
     let zero = I256::from_i32(&e, 0);
     let ratio = c_math::calc_join_ratio(&e, pool_total, pool_amount_out);
     assert_with_error!(&e, ratio > zero, Error::ErrMathApprox);
 
-    let tokens = read_tokens(&e);
     let mut records = read_record(&e);
     for i in 0..tokens.len() {
         let t = tokens.get_unchecked(i);
@@ -72,6 +78,13 @@ pub fn execute_join_pool(e: Env, pool_amount_out: i128, max_amounts_in: Vec<i128
 pub fn execute_exit_pool(e: Env, pool_amount_in: i128, min_amounts_out: Vec<i128>, user: Address) {
     assert_with_error!(&e, pool_amount_in > 0, Error::ErrNegativeOrZero);
 
+    let tokens = read_tokens(&e);
+    assert_with_error!(
+        &e,
+        min_amounts_out.len() == tokens.len(),
+        Error::ErrInvalidVectorLen
+    );
+
     let pool_total = get_total_shares(&e);
     let zero = I256::from_i32(&e, 0);
     let ratio = c_math::calc_exit_ratio(&e, pool_total, pool_amount_in);
@@ -79,7 +92,6 @@ pub fn execute_exit_pool(e: Env, pool_amount_in: i128, min_amounts_out: Vec<i128
     pull_shares(&e, &user, pool_amount_in);
     burn_shares(&e, pool_amount_in);
 
-    let tokens = read_tokens(&e);
     let mut records = read_record(&e);
     for i in 0..tokens.len() {
         let t = tokens.get_unchecked(i);

--- a/contracts/src/tests/c_pool_join_exit.rs
+++ b/contracts/src/tests/c_pool_join_exit.rs
@@ -92,6 +92,35 @@ fn test_join_exit() {
         )))
     );
 
+    // verify input vector length checks
+    let short_amounts_in = vec![
+        &env,
+        above_in_fixed.get_unchecked(0),
+        above_in_fixed.get_unchecked(1),
+    ];
+    let result = comet.try_join_pool(&join_amount_fixed, &short_amounts_in, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrInvalidVectorLen as u32
+        )))
+    );
+
+    let long_amounts_in = vec![
+        &env,
+        above_in_fixed.get_unchecked(0),
+        above_in_fixed.get_unchecked(1),
+        above_in_fixed.get_unchecked(2),
+        i128::MAX,
+    ];
+    let result = comet.try_join_pool(&join_amount_fixed, &long_amounts_in, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrInvalidVectorLen as u32
+        )))
+    );
+
     // verify limit in
     let mut below_in_fixed = above_in_fixed.clone();
     below_in_fixed.set(2, below_in_fixed.get_unchecked(2) - 1001);
@@ -223,6 +252,35 @@ fn test_join_exit() {
         result.err(),
         Some(Ok(Error::from_contract_error(
             CometError::ErrNegativeOrZero as u32
+        )))
+    );
+
+    // verify output vector length checks
+    let short_amounts_out = vec![
+        &env,
+        below_out_fixed.get_unchecked(0),
+        below_out_fixed.get_unchecked(1),
+    ];
+    let result = comet.try_exit_pool(&exit_amount_fixed, &short_amounts_out, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrInvalidVectorLen as u32
+        )))
+    );
+
+    let long_amounts_out = vec![
+        &env,
+        below_out_fixed.get_unchecked(0),
+        below_out_fixed.get_unchecked(1),
+        below_out_fixed.get_unchecked(2),
+        0,
+    ];
+    let result = comet.try_exit_pool(&exit_amount_fixed, &long_amounts_out, &user);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrInvalidVectorLen as u32
         )))
     );
 


### PR DESCRIPTION
## Summary

- Require `max_amounts_in` to contain exactly one value per pool token in `join_pool`.
- Require `min_amounts_out` to contain exactly one value per pool token in `exit_pool`.
- Return the existing `ErrInvalidVectorLen` contract error for both shorter and longer vectors.
- Perform the checks before ratio calculation, share burning, token transfers, or reserve mutation.

## Motivation

Join and exit iterate over the pool tokens and index the caller-provided limit vectors with `get_unchecked`. A shorter vector therefore produces a host bounds error, while a longer vector is accepted with its extra values silently ignored. Requiring an exact length gives callers a deterministic contract error and prevents ambiguous limit handling.

## Testing

- Added regression coverage for shorter and longer vectors on both `join_pool` and `exit_pool`.
- Verified the existing exact-length join and exit flows continue to succeed after the malformed calls.
- `cargo +1.78.0 test --workspace` passes all 21 tests.
- `cargo +1.78.0 build --release --target wasm32-unknown-unknown -p contracts` succeeds.