### PR TITLE
Enforce pool-favoring rounding for single-sided liquidity operations

### DIFF
--- a/contracts/src/c_math.rs
+++ b/contracts/src/c_math.rs
@@ -117,7 +117,7 @@ pub fn calc_lp_token_amount_given_token_deposits_in(
     let fee = upscale(e, swap_fee, STROOP_SCALAR);
 
     let normalized_weight = upscale(e, in_record.weight, STROOP_SCALAR);
-    let zaz = bone.sub(&normalized_weight).fixed_mul_floor(e, &fee, &bone);
+    let zaz = bone.sub(&normalized_weight).fixed_mul_ceil(e, &fee, &bone);
     let token_amount_in_after_fee = token_amount_in.fixed_mul_floor(&e, &bone.sub(&zaz), &bone);
 
     let new_token_balance_in = token_balance_in.add(&token_amount_in_after_fee);
@@ -156,11 +156,11 @@ pub fn calc_token_deposits_in_given_lp_token_amount(
     let pool_ratio = new_pool_supply.fixed_div_ceil(&e, &pool_supply, &bone);
 
     let boo = bone.fixed_div_ceil(e, &normalized_weight, &bone);
-    let token_in_ratio = c_pow(e, &pool_ratio, &boo, false);
+    let token_in_ratio = c_pow(e, &pool_ratio, &boo, true);
     let new_token_balance_in = token_balance_in.fixed_mul_ceil(&e, &token_in_ratio, &bone);
 
     let token_amount_in_after_fee = sub_no_negative(e, &new_token_balance_in, &token_balance_in);
-    let zar = bone.sub(&normalized_weight).fixed_mul_floor(e, &fee, &bone);
+    let zar = bone.sub(&normalized_weight).fixed_mul_ceil(e, &fee, &bone);
     let result = token_amount_in_after_fee.fixed_div_ceil(&e, &bone.sub(&zar), &bone);
 
     downscale_ceil(e, &result, in_record.scalar)
@@ -186,14 +186,14 @@ pub fn calc_lp_token_amount_given_token_withdrawal_amount(
     let normalized_weight = upscale(e, out_record.weight, STROOP_SCALAR);
 
     let zoo = bone.sub(&normalized_weight);
-    let zar = zoo.fixed_mul_floor(e, &fee, &bone);
+    let zar = zoo.fixed_mul_ceil(e, &fee, &bone);
 
     let token_amount_out_before_fee = token_amount_out.fixed_div_ceil(&e, &bone.sub(&zar), &bone);
     let new_token_balance_out = token_balance_out.sub(&token_amount_out_before_fee);
-    let balance_ratio = new_token_balance_out.fixed_div_ceil(&e, &token_balance_out, &bone);
+    let balance_ratio = new_token_balance_out.fixed_div_floor(&e, &token_balance_out, &bone);
 
-    let pool_ratio = c_pow(e, &balance_ratio, &normalized_weight, true);
-    let new_pool_supply = pool_ratio.fixed_mul_ceil(&e, &pool_supply, &bone);
+    let pool_ratio = c_pow(e, &balance_ratio, &normalized_weight, false);
+    let new_pool_supply = pool_ratio.fixed_mul_floor(&e, &pool_supply, &bone);
     let result = sub_no_negative(&e, &pool_supply, &new_pool_supply);
 
     downscale_ceil(e, &result, STROOP_SCALAR)
@@ -219,16 +219,16 @@ pub fn calc_token_withdrawal_amount_given_lp_token_amount(
     let normalized_weight = upscale(e, out_record.weight, STROOP_SCALAR);
 
     let new_pool_supply = pool_supply.sub(&pool_amount_in);
-    let pool_ratio = new_pool_supply.fixed_div_floor(&e, &pool_supply, &bone);
+    let pool_ratio = new_pool_supply.fixed_div_ceil(&e, &pool_supply, &bone);
 
     let exp = bone.fixed_div_floor(e, &normalized_weight, &bone);
-    let token_out_ratio = c_pow(e, &pool_ratio, &exp, false);
-    let new_token_balance_out = token_balance_out.fixed_mul_floor(&e, &token_out_ratio, &bone);
+    let token_out_ratio = c_pow(e, &pool_ratio, &exp, true);
+    let new_token_balance_out = token_balance_out.fixed_mul_ceil(&e, &token_out_ratio, &bone);
 
     let token_amount_out_before_fee =
         sub_no_negative(e, &token_balance_out, &new_token_balance_out);
 
-    let zaz = bone.sub(&normalized_weight).fixed_mul_floor(e, &fee, &bone);
+    let zaz = bone.sub(&normalized_weight).fixed_mul_ceil(e, &fee, &bone);
     let result = token_amount_out_before_fee.fixed_mul_floor(&e, &bone.sub(&zaz), &bone);
 
     downscale_floor(e, &result, out_record.scalar)
@@ -350,6 +350,80 @@ mod tests {
         let x = I256::from_i128(&env, i128::MAX);
         let too_large = x.mul(&I256::from_i128(&env, STROOP_SCALAR)).add(&x);
         downscale_ceil(&env, &too_large, STROOP_SCALAR);
+    }
+
+    #[test]
+    fn test_single_sided_math_favors_pool() {
+        let env = Env::default();
+        let balance = 99_999_999 * STROOP;
+        let weight = 8 * STROOP / 10;
+        let supply = 100 * STROOP;
+        let swap_fee = 0_0030000;
+        let record = Record {
+            balance,
+            weight,
+            scalar: STROOP_SCALAR,
+            index: 0,
+        };
+        let balance_f64 = balance as f64 / STROOP as f64;
+        let weight_f64 = weight as f64 / STROOP as f64;
+        let supply_f64 = supply as f64 / STROOP as f64;
+        let fee_f64 = swap_fee as f64 / STROOP as f64;
+        let fee_factor = 1.0 - (1.0 - weight_f64) * fee_f64;
+
+        let token_amount_in = 300_000_002_000_000;
+        let token_amount_in_f64 = token_amount_in as f64 / STROOP as f64;
+        let expected_pool_out = supply_f64
+            * ((1.0 + token_amount_in_f64 * fee_factor / balance_f64).powf(weight_f64) - 1.0);
+        let pool_amount_out = calc_lp_token_amount_given_token_deposits_in(
+            &env,
+            &record,
+            supply,
+            token_amount_in,
+            swap_fee,
+        );
+        assert!(pool_amount_out <= (expected_pool_out * STROOP as f64).floor() as i128);
+
+        let pool_amount_out = 420;
+        let pool_amount_out_f64 = pool_amount_out as f64 / STROOP as f64;
+        let expected_token_in = balance_f64
+            * ((1.0 + pool_amount_out_f64 / supply_f64).powf(1.0 / weight_f64) - 1.0)
+            / fee_factor;
+        let token_amount_in = calc_token_deposits_in_given_lp_token_amount(
+            &env,
+            &record,
+            supply,
+            pool_amount_out,
+            swap_fee,
+        );
+        assert!(token_amount_in >= (expected_token_in * STROOP as f64).ceil() as i128);
+
+        let pool_amount_in = 25 * STROOP;
+        let pool_amount_in_f64 = pool_amount_in as f64 / STROOP as f64;
+        let expected_token_out = balance_f64
+            * (1.0 - (1.0 - pool_amount_in_f64 / supply_f64).powf(1.0 / weight_f64))
+            * fee_factor;
+        let token_amount_out = calc_token_withdrawal_amount_given_lp_token_amount(
+            &env,
+            &record,
+            supply,
+            pool_amount_in,
+            swap_fee,
+        );
+        assert!(token_amount_out <= (expected_token_out * STROOP as f64).floor() as i128);
+
+        let token_amount_out = 42_000_000;
+        let token_amount_out_f64 = token_amount_out as f64 / STROOP as f64;
+        let expected_pool_in = supply_f64
+            * (1.0 - (1.0 - token_amount_out_f64 / fee_factor / balance_f64).powf(weight_f64));
+        let pool_amount_in = calc_lp_token_amount_given_token_withdrawal_amount(
+            &env,
+            &record,
+            supply,
+            token_amount_out,
+            swap_fee,
+        );
+        assert!(pool_amount_in >= (expected_pool_in * STROOP as f64).ceil() as i128);
     }
 
     #[test]

--- a/contracts/src/c_num.rs
+++ b/contracts/src/c_num.rs
@@ -19,6 +19,8 @@ pub fn sub_no_negative(e: &Env, a: &I256, b: &I256) -> I256 {
 ///
 /// Approximates the result such that:
 /// -> base^(int exp) * approximate of base^(decimal exp)
+///
+/// Returns an upper bound when `round_up` is true and a lower bound otherwise.
 pub fn c_pow(e: &Env, base: &I256, exp: &I256, round_up: bool) -> I256 {
     assert_with_error!(
         e,
@@ -34,7 +36,12 @@ pub fn c_pow(e: &Env, base: &I256, exp: &I256, round_up: bool) -> I256 {
     let bone = I256::from_i128(e, BONE);
     let int = exp.div(&bone);
     let remain = exp.sub(&int.mul(&bone));
-    let whole_pow = c_powi(e, &base, &(int.to_i128().unwrap_optimized() as u32));
+    let whole_pow = c_powi(
+        e,
+        &base,
+        &(int.to_i128().unwrap_optimized() as u32),
+        round_up,
+    );
     if remain == I256::from_i128(e, 0) {
         return whole_pow;
     }
@@ -45,24 +52,42 @@ pub fn c_pow(e: &Env, base: &I256, exp: &I256, round_up: bool) -> I256 {
         &I256::from_i128(e, CPOW_PRECISION),
         round_up,
     );
-    if round_up {
+    let result = if round_up {
         whole_pow.fixed_mul_ceil(e, &partial_result, &bone)
     } else {
         whole_pow.fixed_mul_floor(e, &partial_result, &bone)
+    };
+
+    // Account for the final fixed-point unit of approximation uncertainty.
+    let one = I256::from_i32(e, 1);
+    if round_up {
+        result.add(&one)
+    } else if result > one {
+        result.sub(&one)
+    } else {
+        I256::from_i32(e, 0)
     }
 }
 
 // Calculate a^n where n is an integer
-fn c_powi(e: &Env, a: &I256, n: &u32) -> I256 {
+fn c_powi(e: &Env, a: &I256, n: &u32, round_up: bool) -> I256 {
     let bone = I256::from_i128(e, BONE);
     let mut z = if n % 2 != 0 { a.clone() } else { bone.clone() };
 
     let mut a = a.clone();
     let mut n = n / 2;
     while n != 0 {
-        a = a.fixed_mul_floor(e, &a, &bone);
+        a = if round_up {
+            a.fixed_mul_ceil(e, &a, &bone)
+        } else {
+            a.fixed_mul_floor(e, &a, &bone)
+        };
         if n % 2 != 0 {
-            z = z.fixed_mul_floor(e, &a, &bone);
+            z = if round_up {
+                z.fixed_mul_ceil(e, &a, &bone)
+            } else {
+                z.fixed_mul_floor(e, &a, &bone)
+            };
         }
         n = n / 2
     }
@@ -99,16 +124,15 @@ fn c_pow_approx(e: &Env, base: &I256, exp: &I256, precision: &I256, round_up: bo
             break;
         }
     }
-    // the series has predicatable approximations bounds, so we can adjust the final sum by
-    // the final term to (almost) ensure the sum is either an under or over estimate based
-    // on the rounding direction.
+    // The series has predictable approximation bounds, so adjust the final sum by the final
+    // term to put it on the requested side of the approximation.
     if x > zero {
         // series will oscillate due to negative `c` values and a starting positive value.
         if term > zero && !round_up {
             // the final applied term was additive - the current sum is likely an overestimate
             sum = sum.sub(&term);
         } else if term < zero && round_up {
-            // the final applied term was subtractive - the current sum is likely an understimate
+            // the final applied term was subtractive - the current sum is likely an underestimate
             sum = sum.sub(&term);
         }
     } else if !round_up {

--- a/contracts/src/tests/c_num_test.rs
+++ b/contracts/src/tests/c_num_test.rs
@@ -29,3 +29,61 @@ fn test_c_pow_high() {
         false,
     );
 }
+
+#[test]
+fn test_c_pow_integer_rounding_direction() {
+    let env = Env::default();
+    let base = I256::from_i128(&env, BONE + 1);
+    let exp = I256::from_i128(&env, 2 * BONE);
+
+    assert_eq!(c_pow(&env, &base, &exp, false).to_i128().unwrap(), BONE + 2);
+    assert_eq!(c_pow(&env, &base, &exp, true).to_i128().unwrap(), BONE + 3);
+}
+
+#[test]
+fn test_c_pow_fractional_rounding_direction() {
+    let env = Env::default();
+    // Expected bounds were calculated with 100-digit decimal precision.
+    let cases = [
+        (
+            750_000_000_000_000_000,
+            1_250_000_000_000_000_000,
+            697_953_644_326_574_699,
+            697_953_644_326_574_700,
+        ),
+        (
+            1_300_000_000_000_000_000,
+            800_000_000_000_000_000,
+            1_233_544_104_071_173_995,
+            1_233_544_104_071_173_996,
+        ),
+        (
+            999_999_580_000_000_000,
+            1_250_000_000_000_000_000,
+            999_999_475_000_027_562,
+            999_999_475_000_027_563,
+        ),
+        (
+            1_000_000_420_000_000_000,
+            1_250_000_000_000_000_000,
+            1_000_000_525_000_027_562,
+            1_000_000_525_000_027_563,
+        ),
+    ];
+
+    for (base, exp, expected_floor, expected_ceil) in cases {
+        let base_256 = I256::from_i128(&env, base);
+        let exp_256 = I256::from_i128(&env, exp);
+        let rounded_down = c_pow(&env, &base_256, &exp_256, false).to_i128().unwrap();
+        let rounded_up = c_pow(&env, &base_256, &exp_256, true).to_i128().unwrap();
+
+        assert!(
+            rounded_down <= expected_floor,
+            "round down exceeded base={base} exp={exp}: result={rounded_down} floor={expected_floor}"
+        );
+        assert!(
+            rounded_up >= expected_ceil,
+            "round up fell below base={base} exp={exp}: result={rounded_up} ceil={expected_ceil}"
+        );
+    }
+}

--- a/contracts/src/tests/c_pool_single_sided.rs
+++ b/contracts/src/tests/c_pool_single_sided.rs
@@ -21,6 +21,17 @@ use super::{
     utils::{create_comet_pool, create_stellar_token},
 };
 
+fn sync_balancer_state(
+    comet: &CometPoolContractClient<'_>,
+    balancer: &mut BalancerPool,
+    token_1: &Address,
+    token_2: &Address,
+) {
+    balancer.balances[0] = comet.get_balance(token_1) as f64 / STROOP as f64;
+    balancer.balances[1] = comet.get_balance(token_2) as f64 / STROOP as f64;
+    balancer.supply = comet.get_total_supply() as f64 / STROOP as f64;
+}
+
 #[test]
 fn test_single_sided_dep() {
     let env = Env::default();
@@ -144,6 +155,7 @@ fn test_single_sided_dep() {
 
     //***** single sided dep given pool mint ******//
 
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     env.mock_all_auths();
     let mint_amount = 1.0;
     let mint_amount_fixed = mint_amount.to_i128(&7);
@@ -363,6 +375,7 @@ fn test_single_sided_wdr() {
 
     //***** single sided wdr given token out ******//
 
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     env.mock_all_auths();
     let bal_token_out = 1.0;
     let token_out_fixed = bal_token_out.to_i128(&7);
@@ -498,6 +511,7 @@ fn test_single_sided_deposit_large_price() {
     assert!(res_lp_out_1 <= bal_lp_out_1);
     assert_approx_eq_rel(res_lp_out_1, bal_lp_out_1, 0_0001000);
 
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     let lp_out_1 = 5.0;
     let lp_out_1_fixed = lp_out_1.to_i128(&7);
     let bal_token_in_1 = balancer.single_sided_dep_given_out(0, lp_out_1).to_i128(&7);
@@ -507,6 +521,7 @@ fn test_single_sided_deposit_large_price() {
     assert_approx_eq_rel(res_token_in_1, bal_token_in_1, 0_0001000);
 
     // token 2
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     let token_in_2 = 30_000_000.2;
     let token_in_2_fixed = token_in_2.to_i128(&7);
     let bal_lp_out_2 = balancer
@@ -517,6 +532,7 @@ fn test_single_sided_deposit_large_price() {
     assert!(res_lp_out_2 <= bal_lp_out_2);
     assert_approx_eq_rel(res_lp_out_2, bal_lp_out_2, 0_0001000);
 
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     let lp_out_2 = 0.000042;
     let lp_out_2_fixed = lp_out_2.to_i128(&7);
     let bal_token_in_2 = balancer.single_sided_dep_given_out(1, lp_out_2).to_i128(&7);
@@ -570,6 +586,7 @@ fn test_single_sided_withdraw_large_price() {
     assert!(res_token_out_1 <= bal_token_out_1);
     assert_approx_eq_rel(res_token_out_1, bal_token_out_1, 0_0001000);
 
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     let token_out_1 = 30.0;
     let token_out_1_fixed = token_out_1.to_i128(&7);
     let bal_lp_in_1 = balancer
@@ -581,17 +598,16 @@ fn test_single_sided_withdraw_large_price() {
     assert_approx_eq_rel(res_lp_in_1, bal_lp_in_1, 0_0001000);
 
     // token 2
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     let lp_in_2 = 25.0;
     let lp_in_2_fixed = lp_in_2.to_i128(&7);
     let bal_token_out_2 = balancer.single_sided_wd_given_in(1, lp_in_2).to_i128(&7);
     let res_token_out_2 =
         comet.wdr_tokn_amt_in_get_lp_tokns_out(&token_2, &lp_in_2_fixed, &1, &admin);
-    // assert!(res_token_out_2 <= bal_token_out_2); -> fails
-    // -> next check ensures result is close to floating point result by a basis point
-    //    while its possible float error is worse than rounding error at these scales, this
-    //    ensures the diff is held within the min fee to avoid abuse
+    assert!(res_token_out_2 <= bal_token_out_2);
     assert_approx_eq_rel(res_token_out_2, bal_token_out_2, 0_0001000);
 
+    sync_balancer_state(&comet, &mut balancer, &token_1, &token_2);
     let token_out_2 = 4.2;
     let token_out_2_fixed = token_out_2.to_i128(&7);
     let bal_lp_in_2 = balancer


### PR DESCRIPTION
## Summary

This PR makes rounding consistently favor the pool across all four single-sided liquidity calculations: exact token deposit for LP output, exact LP output for token deposit, exact LP withdrawal for token output, and exact token output for LP withdrawal.

It applies the appropriate floor or ceiling at each fee, ratio, power, balance, supply, and downscaling step. It also makes integer exponentiation honor the requested rounding direction and accounts for the final fixed-point unit of uncertainty in fractional power approximations.

## Test coverage

- Adds high-precision regression cases for upper and lower `c_pow` bounds with integer and fractional exponents.
- Adds direct assertions that each single-sided calculation returns no more output or requires no less input than its mathematical reference value.
- Synchronizes the floating-point reference pool with contract state between operations so comparisons begin from identical balances and supply.
- Restores the previously disabled pool-favoring assertion for a large-price single-sided withdrawal.

## Validation

- `cargo +1.81 fmt --all -- --check`
- `cargo +1.81 check --workspace --all-targets`
- `cargo +1.81 test -p factory`
- Focused numeric, single-sided math, large-price deposit and withdrawal, and successful swap-path tests

The optimized contract WASM increases by 83 bytes, from 28,775 to 28,858 bytes (+0.29%). In a representative 60/40 pool benchmark, single-sided operation CPU usage ranged from a 1.31% reduction to a 4.10% increase, with memory usage ranging from a 0.43% reduction to a 1.23% increase. The public contract API and storage layout are unchanged.