### PR TITLE
Prevent pool supply from reaching zero

### DIFF
--- a/contracts/src/c_consts.rs
+++ b/contracts/src/c_consts.rs
@@ -13,6 +13,8 @@ pub const STROOP_SCALAR: i128 = 10i128.pow(11);
 pub const MAX_IN_RATIO: i128 = (STROOP / 3) + 1;
 pub const MAX_OUT_RATIO: i128 = (STROOP / 3) + 1;
 pub const INIT_POOL_SUPPLY: i128 = STROOP * 100;
+/// One raw LP token unit is permanently locked to keep pool supply nonzero.
+pub const MIN_POOL_SUPPLY: i128 = 1;
 pub const MIN_FEE: i128 = 10; // 0.0001%
 pub const MAX_FEE: i128 = STROOP / 10; // 10%
 pub const MIN_BOUND_TOKENS: u32 = 2;

--- a/contracts/src/c_pool/call_logic/init.rs
+++ b/contracts/src/c_pool/call_logic/init.rs
@@ -4,7 +4,10 @@ use soroban_sdk::{
 use soroban_token_sdk::metadata::TokenMetadata;
 
 use crate::{
-    c_consts::{INIT_POOL_SUPPLY, MAX_FEE, MAX_WEIGHT, MIN_BALANCE, MIN_FEE, MIN_WEIGHT, STROOP},
+    c_consts::{
+        INIT_POOL_SUPPLY, MAX_FEE, MAX_WEIGHT, MIN_BALANCE, MIN_FEE, MIN_POOL_SUPPLY, MIN_WEIGHT,
+        STROOP,
+    },
     c_pool::{
         error::Error,
         metadata::{write_controller, write_metadata, write_record, write_swap_fee, write_tokens},
@@ -73,7 +76,8 @@ pub fn execute_init(
         records.set(token.clone(), record);
     }
     assert_with_error!(&e, total_weight == STROOP, Error::ErrTotalWeight);
-    mint_shares(&e, &controller, INIT_POOL_SUPPLY);
+    mint_shares(&e, &e.current_contract_address(), MIN_POOL_SUPPLY);
+    mint_shares(&e, &controller, INIT_POOL_SUPPLY - MIN_POOL_SUPPLY);
     write_swap_fee(&e, swap_fee);
 
     write_record(e, records);

--- a/contracts/src/c_pool/comet.rs
+++ b/contracts/src/c_pool/comet.rs
@@ -17,7 +17,7 @@ use crate::c_pool::{
         read_symbol, read_tokens,
     },
     storage_types::{SHARED_BUMP_AMOUNT, SHARED_LIFETIME_THRESHOLD},
-    token_utility::check_nonnegative_amount,
+    token_utility::{burn_shares_from, check_nonnegative_amount},
 };
 use soroban_sdk::{
     contract, contractimpl, token::TokenInterface, unwrap::UnwrapOptimized, Address, Env, String,
@@ -25,7 +25,7 @@ use soroban_sdk::{
 };
 use soroban_token_sdk::TokenUtils;
 
-use super::metadata::{put_total_shares, write_controller, write_freeze};
+use super::metadata::{write_controller, write_freeze};
 
 #[contract]
 pub struct CometPoolContract;
@@ -332,21 +332,16 @@ impl TokenInterface for CometPoolContract {
 
     fn burn(e: Env, from: Address, amount: i128) {
         from.require_auth();
-        let total = get_total_shares(&e);
-        check_nonnegative_amount(amount);
 
         e.storage()
             .instance()
             .extend_ttl(SHARED_LIFETIME_THRESHOLD, SHARED_BUMP_AMOUNT);
 
-        spend_balance(&e, from.clone(), amount);
-        TokenUtils::new(&e).events().burn(from, amount);
-        put_total_shares(&e, total - amount);
+        burn_shares_from(&e, &from, amount);
     }
 
     fn burn_from(e: Env, spender: Address, from: Address, amount: i128) {
         spender.require_auth();
-        let total = get_total_shares(&e);
         check_nonnegative_amount(amount);
 
         e.storage()
@@ -354,9 +349,7 @@ impl TokenInterface for CometPoolContract {
             .extend_ttl(SHARED_LIFETIME_THRESHOLD, SHARED_BUMP_AMOUNT);
 
         spend_allowance(&e, from.clone(), spender, amount);
-        spend_balance(&e, from.clone(), amount);
-        TokenUtils::new(&e).events().burn(from, amount);
-        put_total_shares(&e, total - amount);
+        burn_shares_from(&e, &from, amount);
     }
 
     fn decimals(e: Env) -> u32 {

--- a/contracts/src/c_pool/error.rs
+++ b/contracts/src/c_pool/error.rs
@@ -42,4 +42,5 @@ pub enum Error {
     ErrInvalidExpirationLedger = 36,
     ErrNegativeOrZero = 37,
     ErrTokenInvalid = 38,
+    ErrMinPoolSupply = 39,
 }

--- a/contracts/src/c_pool/token_utility.rs
+++ b/contracts/src/c_pool/token_utility.rs
@@ -1,9 +1,12 @@
 //! Utilities for the LP Token
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{assert_with_error, Address, Env};
 use soroban_token_sdk::TokenUtils;
+
+use crate::c_consts::MIN_POOL_SUPPLY;
 
 use super::{
     balance::{receive_balance, spend_balance},
+    error::Error,
     metadata::{get_total_shares, put_total_shares},
 };
 
@@ -48,11 +51,21 @@ pub fn pull_shares(e: &Env, from: &Address, amount: i128) {
 
 // Burn the LP Tokens
 pub fn burn_shares(e: &Env, amount: i128) {
-    let total = get_total_shares(e);
     let contract_address = e.current_contract_address();
+    burn_shares_from(e, &contract_address, amount);
+}
+
+// Burn LP Tokens from an address while preserving the minimum pool supply.
+pub fn burn_shares_from(e: &Env, from: &Address, amount: i128) {
     check_nonnegative_amount(amount);
-    spend_balance(e, contract_address.clone(), amount);
-    TokenUtils::new(e).events().burn(contract_address, amount);
+    let total = get_total_shares(e);
+    assert_with_error!(
+        e,
+        preserves_minimum_supply(total, amount),
+        Error::ErrMinPoolSupply
+    );
+    spend_balance(e, from.clone(), amount);
+    TokenUtils::new(e).events().burn(from.clone(), amount);
     put_total_shares(e, total - amount);
 }
 
@@ -60,5 +73,28 @@ pub fn burn_shares(e: &Env, amount: i128) {
 pub fn check_nonnegative_amount(amount: i128) {
     if amount < 0 {
         panic!("negative amount is not allowed: {}", amount)
+    }
+}
+
+fn preserves_minimum_supply(total: i128, amount: i128) -> bool {
+    amount <= total - MIN_POOL_SUPPLY
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preserves_minimum_supply;
+    use crate::c_consts::{INIT_POOL_SUPPLY, MIN_POOL_SUPPLY};
+
+    #[test]
+    fn test_preserves_minimum_supply() {
+        assert!(preserves_minimum_supply(
+            INIT_POOL_SUPPLY,
+            INIT_POOL_SUPPLY - MIN_POOL_SUPPLY
+        ));
+        assert!(!preserves_minimum_supply(
+            INIT_POOL_SUPPLY,
+            INIT_POOL_SUPPLY
+        ));
+        assert!(!preserves_minimum_supply(MIN_POOL_SUPPLY, 1));
     }
 }

--- a/contracts/src/tests/c_pool_init.rs
+++ b/contracts/src/tests/c_pool_init.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
 };
 
 use crate::{
-    c_consts::STROOP,
+    c_consts::{INIT_POOL_SUPPLY, MIN_POOL_SUPPLY, STROOP},
     c_pool::{
         comet::{CometPoolContract, CometPoolContractClient},
         error::Error as CometError,
@@ -203,8 +203,12 @@ fn test_init() {
     assert_eq!(comet.get_normalized_weight(&token_2), 0_6000000);
     assert_eq!(comet.get_balance(&token_1), STROOP);
     assert_eq!(comet.get_balance(&token_2), STROOP);
-    assert_eq!(comet.get_total_supply(), 100 * STROOP);
-    assert_eq!(comet.balance(&controller), 100 * STROOP);
+    assert_eq!(comet.get_total_supply(), INIT_POOL_SUPPLY);
+    assert_eq!(
+        comet.balance(&controller),
+        INIT_POOL_SUPPLY - MIN_POOL_SUPPLY
+    );
+    assert_eq!(comet.balance(&contract_id), MIN_POOL_SUPPLY);
     assert_eq!(token_1_client.balance(&controller), 0);
     assert_eq!(token_2_client.balance(&controller), 0);
     assert_eq!(token_1_client.balance(&contract_id), STROOP);

--- a/contracts/src/tests/c_pool_min_supply.rs
+++ b/contracts/src/tests/c_pool_min_supply.rs
@@ -1,0 +1,104 @@
+#![cfg(test)]
+
+use sep_41_token::testutils::MockTokenClient;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
+
+use crate::{
+    c_consts::{INIT_POOL_SUPPLY, MIN_POOL_SUPPLY, STROOP},
+    c_pool::comet::CometPoolContractClient,
+    tests::utils::{create_comet_pool, create_stellar_token},
+};
+
+fn create_pool(e: &Env) -> (Address, Address, Vec<Address>) {
+    e.mock_all_auths();
+    e.budget().reset_unlimited();
+
+    let controller = Address::generate(e);
+    let token_1 = create_stellar_token(e, &controller);
+    let token_2 = create_stellar_token(e, &controller);
+    let balances = vec![e, 100 * STROOP, 100 * STROOP];
+
+    MockTokenClient::new(e, &token_1).mint(&controller, &balances.get_unchecked(0));
+    MockTokenClient::new(e, &token_2).mint(&controller, &balances.get_unchecked(1));
+
+    let tokens = vec![e, token_1, token_2];
+    let pool = create_comet_pool(
+        e,
+        &controller,
+        &tokens,
+        &vec![e, 5 * STROOP / 10, 5 * STROOP / 10],
+        &balances,
+        0_0030000,
+    );
+
+    (pool, controller, tokens)
+}
+
+#[test]
+fn test_initialization_locks_minimum_pool_supply() {
+    let e = Env::default();
+    let (pool, controller, _) = create_pool(&e);
+    let comet = CometPoolContractClient::new(&e, &pool);
+
+    assert_eq!(comet.get_total_supply(), INIT_POOL_SUPPLY);
+    assert_eq!(
+        comet.balance(&controller),
+        INIT_POOL_SUPPLY - MIN_POOL_SUPPLY
+    );
+    assert_eq!(comet.balance(&pool), MIN_POOL_SUPPLY);
+}
+
+#[test]
+fn test_exit_all_user_shares_preserves_usable_pool() {
+    let e = Env::default();
+    let (pool, controller, tokens) = create_pool(&e);
+    let comet = CometPoolContractClient::new(&e, &pool);
+
+    comet.exit_pool(
+        &(INIT_POOL_SUPPLY - MIN_POOL_SUPPLY),
+        &vec![&e, 0, 0],
+        &controller,
+    );
+
+    assert_eq!(comet.get_total_supply(), MIN_POOL_SUPPLY);
+    assert_eq!(comet.balance(&controller), 0);
+    assert_eq!(comet.balance(&pool), MIN_POOL_SUPPLY);
+    assert_eq!(comet.get_balance(&tokens.get_unchecked(0)), 1);
+    assert_eq!(comet.get_balance(&tokens.get_unchecked(1)), 1);
+
+    comet.join_pool(&1, &vec![&e, 1, 1], &controller);
+
+    assert_eq!(comet.get_total_supply(), MIN_POOL_SUPPLY + 1);
+    assert_eq!(comet.get_balance(&tokens.get_unchecked(0)), 2);
+    assert_eq!(comet.get_balance(&tokens.get_unchecked(1)), 2);
+}
+
+#[test]
+fn test_burn_all_user_shares_preserves_minimum_supply() {
+    let e = Env::default();
+    let (pool, controller, _) = create_pool(&e);
+    let comet = CometPoolContractClient::new(&e, &pool);
+
+    comet.burn(&controller, &(INIT_POOL_SUPPLY - MIN_POOL_SUPPLY));
+
+    assert_eq!(comet.get_total_supply(), MIN_POOL_SUPPLY);
+    assert_eq!(comet.balance(&controller), 0);
+    assert_eq!(comet.balance(&pool), MIN_POOL_SUPPLY);
+}
+
+#[test]
+fn test_burn_from_all_user_shares_preserves_minimum_supply() {
+    let e = Env::default();
+    let (pool, controller, _) = create_pool(&e);
+    let comet = CometPoolContractClient::new(&e, &pool);
+    let spender = Address::generate(&e);
+    let burn_amount = INIT_POOL_SUPPLY - MIN_POOL_SUPPLY;
+
+    comet.approve(&controller, &spender, &burn_amount, &100);
+    comet.burn_from(&spender, &controller, &burn_amount);
+
+    assert_eq!(comet.get_total_supply(), MIN_POOL_SUPPLY);
+    assert_eq!(comet.balance(&controller), 0);
+    assert_eq!(comet.balance(&pool), MIN_POOL_SUPPLY);
+    assert_eq!(comet.allowance(&controller, &spender), 0);
+}

--- a/contracts/src/tests/c_pool_test.rs
+++ b/contracts/src/tests/c_pool_test.rs
@@ -2,7 +2,7 @@
 
 use std::println;
 extern crate std;
-use crate::c_consts::STROOP;
+use crate::c_consts::{INIT_POOL_SUPPLY, MIN_POOL_SUPPLY};
 use crate::c_pool::comet::CometPoolContractClient;
 use crate::tests::utils::create_comet_pool;
 use sep_41_token::testutils::{MockTokenClient, MockTokenWASM};
@@ -91,7 +91,10 @@ fn test_pool_functions() {
     assert!(current_tokens.contains(&token3.address));
     assert_eq!(current_tokens.len(), 3);
     let controller = client.get_controller();
-    assert_eq!(client.balance(&controller), 100 * STROOP);
+    assert_eq!(
+        client.balance(&controller),
+        INIT_POOL_SUPPLY - MIN_POOL_SUPPLY
+    );
 
     token1.approve(&user1, &contract_id, &i128::MAX, &200);
     token2.approve(&user1, &contract_id, &i128::MAX, &200);

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -6,6 +6,7 @@ pub mod c_pool_all;
 pub mod c_pool_dif_decimals;
 pub mod c_pool_init;
 pub mod c_pool_join_exit;
+pub mod c_pool_min_supply;
 pub mod c_pool_single_sided;
 pub mod c_pool_swap;
 pub mod c_pool_test;


### PR DESCRIPTION
## Summary

This PR prevents a Comet pool's LP token supply from reaching zero. A zero supply permanently disables supply-dependent liquidity calculations, and reaching it through the public SEP-41 burn methods can leave the underlying reserves trapped in the pool.

Initialization now assigns one raw LP token unit (`0.0000001` LP) to the pool contract and assigns the remaining initial supply to the controller, preserving the existing total initial supply and underlying reserve amounts. All supply-decreasing paths use a centralized burn helper that rejects any operation which would reduce total supply below this minimum.

The invariant covers proportional exits, both single-sided withdrawal paths, `burn`, and `burn_from`. The public contract API and storage-key layout are unchanged.

## Test coverage

- Verifies initialization locks the minimum supply while preserving total initial supply.
- Verifies the controller can exit every externally held LP token without reducing supply below the minimum.
- Verifies the remaining pool can accept a subsequent join and is not permanently disabled.
- Verifies `burn` and `burn_from` can remove every externally held LP token while preserving the locked reserve.
- Verifies the minimum-supply boundary predicate accepts the exact boundary and rejects burns below it.

## Validation

- `cargo +1.81 fmt --all -- --check`
- `cargo +1.81 check --workspace --all-targets`
- Minimum-supply, general pool, mixed-decimal, swap, single-sided liquidity, and factory tests
- Optimized WASM size: 28,695 bytes, 80 bytes smaller than the `main` baseline