### PR TITLE
Return `ErrNotBound` from getters for unbound tokens

### DIFF
--- a/contracts/src/c_pool/call_logic/getter.rs
+++ b/contracts/src/c_pool/call_logic/getter.rs
@@ -1,15 +1,35 @@
-use soroban_sdk::{unwrap::UnwrapOptimized, Address, Env};
+use soroban_sdk::{panic_with_error, Address, Env, Map};
 
 use crate::{
     c_math::calc_spot_price,
-    c_pool::metadata::{read_record, read_swap_fee},
+    c_pool::{
+        error::Error,
+        metadata::{read_record, read_swap_fee},
+        storage_types::Record,
+    },
 };
+
+fn find_record(record: &Map<Address, Record>, token: Address) -> Result<Record, Error> {
+    record.get(token).ok_or(Error::ErrNotBound)
+}
+
+fn require_record(e: &Env, record: &Map<Address, Record>, token: Address) -> Record {
+    find_record(record, token).unwrap_or_else(|error| panic_with_error!(e, error))
+}
+
+pub fn execute_get_balance(e: Env, token: Address) -> i128 {
+    require_record(&e, &read_record(&e), token).balance
+}
+
+pub fn execute_get_normalized_weight(e: Env, token: Address) -> i128 {
+    require_record(&e, &read_record(&e), token).weight
+}
 
 // Calculate the spot considering the swap fee
 pub fn execute_get_spot_price(e: Env, token_in: Address, token_out: Address) -> i128 {
     let record = read_record(&e);
-    let in_record = record.get(token_in).unwrap_optimized();
-    let out_record = record.get(token_out).unwrap_optimized();
+    let in_record = require_record(&e, &record, token_in);
+    let out_record = require_record(&e, &record, token_out);
     let swap_fee = read_swap_fee(&e);
     calc_spot_price(&in_record, &out_record, swap_fee)
 }
@@ -17,7 +37,32 @@ pub fn execute_get_spot_price(e: Env, token_in: Address, token_out: Address) -> 
 // Get the spot price without considering the swap fee
 pub fn execute_get_spot_price_sans_fee(e: Env, token_in: Address, token_out: Address) -> i128 {
     let record = read_record(&e);
-    let in_record = record.get(token_in).unwrap_optimized();
-    let out_record = record.get(token_out).unwrap_optimized();
+    let in_record = require_record(&e, &record, token_in);
+    let out_record = require_record(&e, &record, token_out);
     calc_spot_price(&in_record, &out_record, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_record;
+    use crate::c_pool::{error::Error, storage_types::Record};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Map};
+
+    #[test]
+    fn test_find_record_reports_not_bound() {
+        let e = Env::default();
+        let token = Address::generate(&e);
+        let missing = Address::generate(&e);
+        let expected = Record {
+            balance: 100,
+            weight: 5_000_000,
+            scalar: 1,
+            index: 0,
+        };
+        let mut records = Map::new(&e);
+        records.set(token.clone(), expected.clone());
+
+        assert_eq!(find_record(&records, token), Ok(expected));
+        assert_eq!(find_record(&records, missing), Err(Error::ErrNotBound));
+    }
 }

--- a/contracts/src/c_pool/comet.rs
+++ b/contracts/src/c_pool/comet.rs
@@ -3,7 +3,10 @@ use crate::c_pool::{
     allowance::{read_allowance, spend_allowance, write_allowance},
     balance::{read_balance, receive_balance, spend_balance},
     call_logic::{
-        getter::{execute_get_spot_price, execute_get_spot_price_sans_fee},
+        getter::{
+            execute_get_balance, execute_get_normalized_weight, execute_get_spot_price,
+            execute_get_spot_price_sans_fee,
+        },
         init::execute_init,
         pool::{
             execute_dep_lp_tokn_amt_out_get_tokn_in, execute_dep_tokn_amt_in_get_lp_tokns_out,
@@ -13,16 +16,13 @@ use crate::c_pool::{
         },
     },
     metadata::{
-        get_total_shares, read_controller, read_decimal, read_name, read_record, read_swap_fee,
-        read_symbol, read_tokens,
+        get_total_shares, read_controller, read_decimal, read_name, read_swap_fee, read_symbol,
+        read_tokens,
     },
     storage_types::{SHARED_BUMP_AMOUNT, SHARED_LIFETIME_THRESHOLD},
     token_utility::check_nonnegative_amount,
 };
-use soroban_sdk::{
-    contract, contractimpl, token::TokenInterface, unwrap::UnwrapOptimized, Address, Env, String,
-    Vec,
-};
+use soroban_sdk::{contract, contractimpl, token::TokenInterface, Address, Env, String, Vec};
 use soroban_token_sdk::TokenUtils;
 
 use super::metadata::{put_total_shares, write_controller, write_freeze};
@@ -242,14 +242,12 @@ impl CometPoolContract {
 
     // Get the balance of the Token
     pub fn get_balance(e: Env, token: Address) -> i128 {
-        let val = read_record(&e).get(token).unwrap_optimized();
-        val.balance
+        execute_get_balance(e, token)
     }
 
     // Get the weight of the token in decimal form with 7 decimals
     pub fn get_normalized_weight(e: Env, token: Address) -> i128 {
-        let val = read_record(&e).get(token).unwrap_optimized();
-        val.weight
+        execute_get_normalized_weight(e, token)
     }
 
     // Calculate the spot considering the swap fee


### PR DESCRIPTION
## Summary

The balance, normalized-weight, and spot-price getters previously used unchecked record unwraps. Querying any of these getters with an unbound token therefore produced a generic host panic instead of the contract's existing `ErrNotBound` error.

This change centralizes token-record lookup and maps missing records to `ErrNotBound`. The checked lookup is used by `get_balance`, `get_normalized_weight`, `get_spot_price`, and `get_spot_price_sans_fee`, including both token positions in the spot-price getters.

## Testing

- Added unit coverage confirming that bound records are returned and missing records map to `ErrNotBound`.
- Ran `cargo +1.81 fmt --all`.
- Ran `cargo +1.81 check --workspace --all-targets`.
- Ran the getter regression test and targeted pool, swap, and factory tests.
- Built and optimized the release WASM; the optimized contract decreased from 28,775 bytes to 28,693 bytes.