### PR TITLE
Require controller acceptance before transfer

### DIFF
--- a/contracts/src/c_pool/comet.rs
+++ b/contracts/src/c_pool/comet.rs
@@ -12,20 +12,28 @@ use crate::c_pool::{
             execute_wdr_tokn_amt_out_get_lp_tokns_in,
         },
     },
+    error::Error,
     metadata::{
-        get_total_shares, read_controller, read_decimal, read_name, read_record, read_swap_fee,
-        read_symbol, read_tokens,
+        get_total_shares, read_controller, read_decimal, read_name, read_pending_controller,
+        read_record, read_swap_fee, read_symbol, read_tokens, remove_pending_controller,
+        write_pending_controller,
     },
     storage_types::{SHARED_BUMP_AMOUNT, SHARED_LIFETIME_THRESHOLD},
     token_utility::check_nonnegative_amount,
 };
 use soroban_sdk::{
-    contract, contractimpl, token::TokenInterface, unwrap::UnwrapOptimized, Address, Env, String,
-    Vec,
+    contract, contractimpl, panic_with_error, symbol_short, token::TokenInterface,
+    unwrap::UnwrapOptimized, Address, Env, String, Vec,
 };
 use soroban_token_sdk::TokenUtils;
 
 use super::metadata::{put_total_shares, write_controller, write_freeze};
+
+pub(crate) fn pending_controller_or_error(
+    pending_controller: Option<Address>,
+) -> Result<Address, Error> {
+    pending_controller.ok_or(Error::ErrNoPendingController)
+}
 
 #[contract]
 pub struct CometPoolContract;
@@ -204,13 +212,46 @@ impl CometPoolContract {
         )
     }
 
-    // Sets the value of the controller address, only can be set by the current controller
+    // Proposes a new controller, replacing any existing proposal. Passing the current controller
+    // cancels the pending transfer. The proposed controller must accept before the change applies.
     pub fn set_controller(e: Env, manager: Address) {
-        read_controller(&e).require_auth();
+        let controller = read_controller(&e);
+        controller.require_auth();
         e.storage()
             .instance()
             .extend_ttl(SHARED_LIFETIME_THRESHOLD, SHARED_BUMP_AMOUNT);
-        write_controller(&e, manager);
+
+        if manager == controller {
+            remove_pending_controller(&e);
+        } else {
+            write_pending_controller(&e, manager.clone());
+        }
+        e.events().publish(
+            (symbol_short!("POOL"), symbol_short!("set_ctrl"), controller),
+            manager,
+        );
+    }
+
+    // Accepts a pending controller transfer. Only the pending controller can authorize acceptance.
+    pub fn accept_controller(e: Env) {
+        e.storage()
+            .instance()
+            .extend_ttl(SHARED_LIFETIME_THRESHOLD, SHARED_BUMP_AMOUNT);
+        let new_controller = pending_controller_or_error(read_pending_controller(&e))
+            .unwrap_or_else(|error| panic_with_error!(&e, error));
+        new_controller.require_auth();
+
+        let previous_controller = read_controller(&e);
+        write_controller(&e, new_controller.clone());
+        remove_pending_controller(&e);
+        e.events().publish(
+            (
+                symbol_short!("POOL"),
+                symbol_short!("acpt_ctrl"),
+                previous_controller,
+            ),
+            new_controller,
+        );
     }
 
     // Only Callable by the Pool Admin

--- a/contracts/src/c_pool/error.rs
+++ b/contracts/src/c_pool/error.rs
@@ -42,4 +42,5 @@ pub enum Error {
     ErrInvalidExpirationLedger = 36,
     ErrNegativeOrZero = 37,
     ErrTokenInvalid = 38,
+    ErrNoPendingController = 39,
 }

--- a/contracts/src/c_pool/metadata.rs
+++ b/contracts/src/c_pool/metadata.rs
@@ -78,6 +78,23 @@ pub fn write_controller(e: &Env, d: Address) {
     e.storage().instance().set(&key, &d);
 }
 
+// Read the pending controller. Off-chain SDKs may decode this instance-storage key directly.
+pub fn read_pending_controller(e: &Env) -> Option<Address> {
+    e.storage()
+        .instance()
+        .get::<DataKey, Address>(&DataKey::PendingController)
+}
+
+// Write the pending controller.
+pub fn write_pending_controller(e: &Env, d: Address) {
+    e.storage().instance().set(&DataKey::PendingController, &d);
+}
+
+// Clear the pending controller.
+pub fn remove_pending_controller(e: &Env) {
+    e.storage().instance().remove(&DataKey::PendingController);
+}
+
 // Read Swap Fee
 pub fn read_swap_fee(e: &Env) -> i128 {
     let key = DataKey::SwapFee;

--- a/contracts/src/c_pool/storage_types.rs
+++ b/contracts/src/c_pool/storage_types.rs
@@ -33,6 +33,8 @@ pub enum DataKey {
     PublicSwap,    // bool
     Finalize,      // bool
     Freeze,        // bool
+    // Address proposed by set_controller; exposed to off-chain SDKs through instance storage.
+    PendingController,
 }
 
 // Data Keys for the LP Token

--- a/contracts/src/tests/c_pool_controller.rs
+++ b/contracts/src/tests/c_pool_controller.rs
@@ -1,0 +1,144 @@
+use crate::{
+    c_consts::STROOP,
+    c_pool::{
+        comet::{pending_controller_or_error, CometPoolContractClient},
+        error::Error as CometError,
+        metadata::read_pending_controller,
+    },
+    tests::utils::{create_comet_pool, create_stellar_token},
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke},
+    token::StellarAssetClient,
+    vec, Address, Env, IntoVal,
+};
+
+fn pending_controller(e: &Env, pool: &Address) -> Option<Address> {
+    e.as_contract(pool, || read_pending_controller(e))
+}
+
+fn create_pool(e: &Env, controller: &Address) -> Address {
+    let token_1 = create_stellar_token(e, controller);
+    let token_2 = create_stellar_token(e, controller);
+    StellarAssetClient::new(e, &token_1).mint(controller, &STROOP);
+    StellarAssetClient::new(e, &token_2).mint(controller, &STROOP);
+    let tokens = vec![e, token_1, token_2];
+    let weights = vec![e, 5_000_000, 5_000_000];
+    let balances = vec![e, STROOP, STROOP];
+    create_comet_pool(e, controller, &tokens, &weights, &balances, 10_000)
+}
+
+fn set_controller(e: &Env, client: &CometPoolContractClient, controller: &Address, next: &Address) {
+    client
+        .mock_auths(&[MockAuth {
+            address: controller,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: &"set_controller",
+                args: vec![e, next.into_val(e)],
+                sub_invokes: &[],
+            },
+        }])
+        .set_controller(next);
+    assert_eq!(e.auths().len(), 1);
+    assert_eq!(e.auths()[0].0, *controller);
+}
+
+fn accept_controller(e: &Env, client: &CometPoolContractClient, controller: &Address) {
+    client
+        .mock_auths(&[MockAuth {
+            address: controller,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: &"accept_controller",
+                args: vec![e],
+                sub_invokes: &[],
+            },
+        }])
+        .accept_controller();
+    assert_eq!(e.auths().len(), 1);
+    assert_eq!(e.auths()[0].0, *controller);
+}
+
+#[test]
+fn test_two_step_controller_transfer() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let controller = Address::generate(&e);
+    let first_candidate = Address::generate(&e);
+    let second_candidate = Address::generate(&e);
+    let third_candidate = Address::generate(&e);
+    let pool = create_pool(&e, &controller);
+    let client = CometPoolContractClient::new(&e, &pool);
+    e.set_auths(&[]);
+
+    set_controller(&e, &client, &controller, &first_candidate);
+    assert_eq!(client.get_controller(), controller);
+    assert_eq!(pending_controller(&e, &pool), Some(first_candidate));
+
+    set_controller(&e, &client, &controller, &second_candidate);
+    assert_eq!(client.get_controller(), controller);
+    assert_eq!(
+        pending_controller(&e, &pool),
+        Some(second_candidate.clone())
+    );
+
+    accept_controller(&e, &client, &second_candidate);
+    assert_eq!(client.get_controller(), second_candidate.clone());
+    assert_eq!(pending_controller(&e, &pool), None);
+
+    set_controller(&e, &client, &second_candidate, &third_candidate);
+    assert_eq!(client.get_controller(), second_candidate);
+    assert_eq!(pending_controller(&e, &pool), Some(third_candidate));
+}
+
+#[test]
+fn test_set_controller_to_current_controller_cancels_transfer() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let controller = Address::generate(&e);
+    let candidate = Address::generate(&e);
+    let pool = create_pool(&e, &controller);
+    let client = CometPoolContractClient::new(&e, &pool);
+    e.set_auths(&[]);
+
+    set_controller(&e, &client, &controller, &candidate);
+    assert_eq!(pending_controller(&e, &pool), Some(candidate));
+
+    set_controller(&e, &client, &controller, &controller);
+    assert_eq!(client.get_controller(), controller);
+    assert_eq!(pending_controller(&e, &pool), None);
+    let event = vec![&e, e.events().all().last_unchecked()];
+    assert_eq!(
+        event,
+        vec![
+            &e,
+            (
+                pool,
+                (
+                    symbol_short!("POOL"),
+                    symbol_short!("set_ctrl"),
+                    controller.clone()
+                )
+                    .into_val(&e),
+                controller.into_val(&e)
+            )
+        ]
+    );
+}
+
+#[test]
+fn test_accept_controller_requires_pending_transfer() {
+    let e = Env::default();
+    let candidate = Address::generate(&e);
+
+    assert_eq!(
+        pending_controller_or_error(None),
+        Err(CometError::ErrNoPendingController)
+    );
+    assert_eq!(
+        pending_controller_or_error(Some(candidate.clone())),
+        Ok(candidate)
+    );
+}

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod utils;
 
 pub mod c_num_test;
 pub mod c_pool_all;
+pub mod c_pool_controller;
 pub mod c_pool_dif_decimals;
 pub mod c_pool_init;
 pub mod c_pool_join_exit;


### PR DESCRIPTION
## Summary

`set_controller` previously replaced the active controller immediately after authorization from only the current controller. A mistyped, inaccessible, or incompatible destination could therefore permanently lock the pool out of controller-only operations.

This change preserves the existing `set_controller(Address)` signature but makes it stage or replace a pending controller. The active controller retains authority until the latest candidate calls the new `accept_controller()` entrypoint and proves control of its address. Successful acceptance updates the active controller and clears the pending state atomically.

Calling `set_controller` with the current controller cancels an outstanding transfer. Proposals, replacements, and cancellations share the `set_ctrl` event: event data different from the active controller represents a proposal or replacement, while matching data represents cancellation. Completed transfers emit `acpt_ctrl`.

Pending state is stored under `DataKey::PendingController`, which is included in the contract type specification so off-chain SDKs can decode it directly without adding a public getter. Calling `accept_controller` without a pending transfer reports the newly appended `ErrNoPendingController` error without changing existing error codes.

## Compatibility

The `set_controller(Address)` contract signature is unchanged, but its behavior is intentionally now asynchronous. Existing controller-rotation tooling must call `accept_controller()` from the proposed address before treating the transfer as complete.

## Testing

- Added regression coverage for proposal, replacement, acceptance, pending-state cleanup, cancellation, subsequent control by the accepted controller, event encoding, and exact authorization identities.
- Ran `cargo +1.81 fmt --all -- --check`.
- Ran `cargo +1.81 check --workspace --all-targets`.
- Ran the controller lifecycle tests, general pool regression, and factory tests.
- Built and optimized the release WASM; the optimized contract increased from 28,775 bytes to 29,239 bytes (+464 bytes).