### PR TITLE
Keep the factory live during registry queries

### DIFF
--- a/factory/src/call_logic/factory.rs
+++ b/factory/src/call_logic/factory.rs
@@ -6,16 +6,13 @@ use crate::{DataKeyFactory, NewPoolEvent};
 
 pub(crate) const DAY_IN_LEDGERS: u32 = 17280;
 
-pub(crate) const INSTANCE_BUMP_AMOUNT: u32 = 31 * DAY_IN_LEDGERS;
-pub(crate) const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
-
-pub(crate) const LARGE_BUMP_AMOUNT: u32 = 120 * DAY_IN_LEDGERS;
-pub(crate) const LARGE_LIFETIME_THRESHOLD: u32 = LARGE_BUMP_AMOUNT - 20 * DAY_IN_LEDGERS;
+pub(crate) const FACTORY_BUMP_AMOUNT: u32 = 120 * DAY_IN_LEDGERS;
+pub(crate) const FACTORY_LIFETIME_THRESHOLD: u32 = FACTORY_BUMP_AMOUNT - 20 * DAY_IN_LEDGERS;
 
 fn extend_instance_ttl(e: &Env) {
     e.storage()
         .instance()
-        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        .extend_ttl(FACTORY_LIFETIME_THRESHOLD, FACTORY_BUMP_AMOUNT);
 }
 
 pub fn execute_init(e: Env, pool_wasm_hash: BytesN<32>) {
@@ -67,7 +64,7 @@ pub fn execute_new_c_pool(
     e.storage().persistent().set(&key, &true);
     e.storage()
         .persistent()
-        .extend_ttl(&key, LARGE_LIFETIME_THRESHOLD, LARGE_BUMP_AMOUNT);
+        .extend_ttl(&key, FACTORY_LIFETIME_THRESHOLD, FACTORY_BUMP_AMOUNT);
     let event: NewPoolEvent = NewPoolEvent {
         caller: controller,
         pool: id.clone(),
@@ -84,7 +81,7 @@ pub fn execute_is_c_pool(e: Env, addr: Address) -> bool {
     if let Some(is_cpool) = e.storage().persistent().get::<DataKeyFactory, bool>(&key) {
         e.storage()
             .persistent()
-            .extend_ttl(&key, LARGE_LIFETIME_THRESHOLD, LARGE_BUMP_AMOUNT);
+            .extend_ttl(&key, FACTORY_LIFETIME_THRESHOLD, FACTORY_BUMP_AMOUNT);
         is_cpool
     } else {
         false

--- a/factory/src/call_logic/factory.rs
+++ b/factory/src/call_logic/factory.rs
@@ -6,13 +6,20 @@ use crate::{DataKeyFactory, NewPoolEvent};
 
 pub(crate) const DAY_IN_LEDGERS: u32 = 17280;
 
-pub(crate) const SHARED_BUMP_AMOUNT: u32 = 31 * DAY_IN_LEDGERS;
-pub(crate) const SHARED_LIFETIME_THRESHOLD: u32 = SHARED_BUMP_AMOUNT - DAY_IN_LEDGERS;
+pub(crate) const INSTANCE_BUMP_AMOUNT: u32 = 31 * DAY_IN_LEDGERS;
+pub(crate) const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
 
 pub(crate) const LARGE_BUMP_AMOUNT: u32 = 120 * DAY_IN_LEDGERS;
 pub(crate) const LARGE_LIFETIME_THRESHOLD: u32 = LARGE_BUMP_AMOUNT - 20 * DAY_IN_LEDGERS;
 
+fn extend_instance_ttl(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
 pub fn execute_init(e: Env, pool_wasm_hash: BytesN<32>) {
+    extend_instance_ttl(&e);
     e.storage()
         .instance()
         .set(&DataKeyFactory::WasmHash, &pool_wasm_hash);
@@ -27,9 +34,7 @@ pub fn execute_new_c_pool(
     balances: Vec<i128>,
     swap_fee: i128,
 ) -> Address {
-    e.storage()
-        .instance()
-        .extend_ttl(SHARED_LIFETIME_THRESHOLD, SHARED_BUMP_AMOUNT);
+    extend_instance_ttl(&e);
     let wasm_hash = e
         .storage()
         .instance()
@@ -74,6 +79,7 @@ pub fn execute_new_c_pool(
 
 // Returns true if the passed Address is a valid Pool
 pub fn execute_is_c_pool(e: Env, addr: Address) -> bool {
+    extend_instance_ttl(&e);
     let key = DataKeyFactory::IsCpool(addr);
     if let Some(is_cpool) = e.storage().persistent().get::<DataKeyFactory, bool>(&key) {
         e.storage()

--- a/factory/src/test.rs
+++ b/factory/src/test.rs
@@ -2,8 +2,32 @@
 
 extern crate std;
 
-use crate::{Factory, FactoryClient};
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, vec, Address, BytesN, Env};
+use crate::{
+    call_logic::factory::{DAY_IN_LEDGERS, INSTANCE_BUMP_AMOUNT},
+    DataKeyFactory, Factory, FactoryClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    vec, xdr, Address, BytesN, Env,
+};
+
+fn instance_live_until(e: &Env, contract_id: &Address) -> u32 {
+    let contract_address: xdr::ScAddress = contract_id.clone().try_into().unwrap();
+    e.to_ledger_snapshot()
+        .ledger_entries
+        .iter()
+        .find_map(|(key, (_, live_until))| match key.as_ref() {
+            xdr::LedgerKey::ContractData(entry)
+                if entry.contract == contract_address
+                    && entry.key == xdr::ScVal::LedgerKeyContractInstance =>
+            {
+                *live_until
+            }
+            _ => None,
+        })
+        .unwrap()
+}
 
 // The contract that will be deployed by the deployer contract.
 mod contract {
@@ -44,4 +68,36 @@ fn test_factory() {
     assert_eq!(pool_client.get_tokens(), tokens);
     assert_eq!(pool_client.get_swap_fee(), swap_fee);
     assert_eq!(pool_client.get_total_supply(), 100 * 1_0000000);
+}
+
+#[test]
+fn test_is_c_pool_extends_factory_instance_ttl() {
+    let env = Env::default();
+    let factory_id = env.register_contract(None, Factory);
+    let client = FactoryClient::new(&env, &factory_id);
+    let wasm_hash = BytesN::from_array(&env, &[0; 32]);
+
+    let initial_live_until = instance_live_until(&env, &factory_id);
+    client.init(&wasm_hash);
+    let initialized_live_until = instance_live_until(&env, &factory_id);
+    assert!(initialized_live_until > initial_live_until);
+
+    env.ledger().with_mut(|ledger| {
+        ledger.sequence_number += DAY_IN_LEDGERS + 1;
+    });
+
+    let unknown_pool = Address::generate(&env);
+    assert!(!client.is_c_pool(&unknown_pool));
+    assert!(!env.as_contract(&factory_id, || {
+        env.storage()
+            .persistent()
+            .has(&DataKeyFactory::IsCpool(unknown_pool.clone()))
+    }));
+
+    let refreshed_live_until = instance_live_until(&env, &factory_id);
+    assert!(refreshed_live_until > initialized_live_until);
+    assert_eq!(
+        refreshed_live_until,
+        env.ledger().sequence() + INSTANCE_BUMP_AMOUNT
+    );
 }

--- a/factory/src/test.rs
+++ b/factory/src/test.rs
@@ -3,7 +3,7 @@
 extern crate std;
 
 use crate::{
-    call_logic::factory::{DAY_IN_LEDGERS, INSTANCE_BUMP_AMOUNT},
+    call_logic::factory::{DAY_IN_LEDGERS, FACTORY_BUMP_AMOUNT, FACTORY_LIFETIME_THRESHOLD},
     DataKeyFactory, Factory, FactoryClient,
 };
 use soroban_sdk::{
@@ -81,9 +81,15 @@ fn test_is_c_pool_extends_factory_instance_ttl() {
     client.init(&wasm_hash);
     let initialized_live_until = instance_live_until(&env, &factory_id);
     assert!(initialized_live_until > initial_live_until);
+    assert_eq!(FACTORY_BUMP_AMOUNT, 120 * DAY_IN_LEDGERS);
+    assert_eq!(FACTORY_LIFETIME_THRESHOLD, 100 * DAY_IN_LEDGERS);
+    assert_eq!(
+        initialized_live_until,
+        env.ledger().sequence() + FACTORY_BUMP_AMOUNT
+    );
 
     env.ledger().with_mut(|ledger| {
-        ledger.sequence_number += DAY_IN_LEDGERS + 1;
+        ledger.sequence_number += FACTORY_BUMP_AMOUNT - FACTORY_LIFETIME_THRESHOLD + 1;
     });
 
     let unknown_pool = Address::generate(&env);
@@ -98,6 +104,6 @@ fn test_is_c_pool_extends_factory_instance_ttl() {
     assert!(refreshed_live_until > initialized_live_until);
     assert_eq!(
         refreshed_live_until,
-        env.ledger().sequence() + INSTANCE_BUMP_AMOUNT
+        env.ledger().sequence() + FACTORY_BUMP_AMOUNT
     );
 }


### PR DESCRIPTION
## Summary

- Centralize the factory instance and WASM TTL extension in a shared helper.
- Refresh the 120-day factory TTL during `init`, `new_c_pool`, and `is_c_pool`.
- Add regression coverage proving that `is_c_pool` refreshes the factory near its TTL threshold without creating a marker for an unknown address.

## Motivation

Previously, `is_c_pool` extended an existing pool-registration marker but did not extend the factory instance and WASM TTL. As a result, active registry use could still allow the factory to expire after 31 days without a pool deployment, requiring restoration before later calls. This change follows Blend v2's tiered TTL approach: frequently renewed factory instance and code with longer-lived persistent registration markers.

## Testing

- `cargo fmt --all -- --check`
- `cargo +1.78.0 test --workspace` (22 passed)