### PR TITLE
Emit events for pool freeze and reserve synchronization

### DIFF
--- a/contracts/src/c_pool/call_logic/pool.rs
+++ b/contracts/src/c_pool/call_logic/pool.rs
@@ -11,7 +11,7 @@ use crate::{
     c_math,
     c_pool::{
         error::Error,
-        event::{DepositEvent, ExitEvent, JoinEvent, SwapEvent, WithdrawEvent},
+        event::{DepositEvent, ExitEvent, GulpEvent, JoinEvent, SwapEvent, WithdrawEvent},
         metadata::{
             get_total_shares, read_freeze, read_record, read_swap_fee, read_tokens, write_record,
         },
@@ -27,9 +27,18 @@ pub fn execute_gulp(e: Env, t: Address) {
         .get(t.clone())
         .unwrap_or_else(|| panic_with_error!(&e, Error::ErrNotBound));
 
-    rec.balance = token::Client::new(&e, &t).balance(&e.current_contract_address());
-    records.set(t, rec);
+    let previous_balance = rec.balance;
+    let new_balance = token::Client::new(&e, &t).balance(&e.current_contract_address());
+    rec.balance = new_balance;
+    records.set(t.clone(), rec);
     write_record(&e, records);
+
+    let event = GulpEvent {
+        token: t,
+        previous_balance,
+        new_balance,
+    };
+    e.events().publish((POOL, symbol_short!("gulp")), event);
 }
 
 pub fn execute_join_pool(e: Env, pool_amount_out: i128, max_amounts_in: Vec<i128>, user: Address) {

--- a/contracts/src/c_pool/comet.rs
+++ b/contracts/src/c_pool/comet.rs
@@ -12,6 +12,7 @@ use crate::c_pool::{
             execute_wdr_tokn_amt_out_get_lp_tokns_in,
         },
     },
+    event::FreezeEvent,
     metadata::{
         get_total_shares, read_controller, read_decimal, read_name, read_record, read_swap_fee,
         read_symbol, read_tokens,
@@ -20,8 +21,8 @@ use crate::c_pool::{
     token_utility::check_nonnegative_amount,
 };
 use soroban_sdk::{
-    contract, contractimpl, token::TokenInterface, unwrap::UnwrapOptimized, Address, Env, String,
-    Vec,
+    contract, contractimpl, symbol_short, token::TokenInterface, unwrap::UnwrapOptimized, Address,
+    Env, String, Vec,
 };
 use soroban_token_sdk::TokenUtils;
 
@@ -216,11 +217,18 @@ impl CometPoolContract {
     // Only Callable by the Pool Admin
     // Freezes Functions and only allows withdrawals
     pub fn set_freeze_status(e: Env, val: bool) {
-        read_controller(&e).require_auth();
+        let controller = read_controller(&e);
+        controller.require_auth();
         e.storage()
             .instance()
             .extend_ttl(SHARED_LIFETIME_THRESHOLD, SHARED_BUMP_AMOUNT);
         write_freeze(&e, val);
+        let event = FreezeEvent {
+            controller,
+            frozen: val,
+        };
+        e.events()
+            .publish((symbol_short!("POOL"), symbol_short!("freeze")), event);
     }
 
     // GETTER FUNCTIONS

--- a/contracts/src/c_pool/event.rs
+++ b/contracts/src/c_pool/event.rs
@@ -48,3 +48,20 @@ pub struct WithdrawEvent {
     pub token_amount_out: i128,
     pub pool_amount_in: i128,
 }
+
+// Freeze Event, emitted when the controller updates the pool's freeze status
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FreezeEvent {
+    pub controller: Address,
+    pub frozen: bool,
+}
+
+// Gulp Event, emitted when recorded reserves are synchronized with the token balance
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GulpEvent {
+    pub token: Address,
+    pub previous_balance: i128,
+    pub new_balance: i128,
+}

--- a/contracts/src/tests/c_pool_events.rs
+++ b/contracts/src/tests/c_pool_events.rs
@@ -1,0 +1,114 @@
+#![cfg(test)]
+
+use sep_41_token::testutils::MockTokenClient;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events as _},
+    vec, Address, Env, Symbol, TryFromVal, Vec,
+};
+
+use crate::{
+    c_consts::STROOP,
+    c_pool::{
+        comet::CometPoolContractClient,
+        event::{FreezeEvent, GulpEvent},
+    },
+    tests::utils::{create_comet_pool, create_stellar_token},
+};
+
+fn assert_pool_event(e: &Env, pool: &Address, name: Symbol) -> soroban_sdk::Val {
+    let events = e.events().all();
+    let (contract, topics, data) = events.last().unwrap();
+    assert_eq!(contract, pool.clone());
+    assert_eq!(topics.len(), 2);
+    assert_eq!(
+        Symbol::try_from_val(e, &topics.get_unchecked(0)).unwrap(),
+        symbol_short!("POOL")
+    );
+    assert_eq!(
+        Symbol::try_from_val(e, &topics.get_unchecked(1)).unwrap(),
+        name
+    );
+    data
+}
+
+fn create_pool(e: &Env) -> (Address, Address, Address) {
+    let controller = Address::generate(e);
+    let token_1 = create_stellar_token(e, &controller);
+    let token_2 = create_stellar_token(e, &controller);
+    let token_1_client = MockTokenClient::new(e, &token_1);
+    let token_2_client = MockTokenClient::new(e, &token_2);
+    let balances: Vec<i128> = vec![e, 100 * STROOP, 100 * STROOP];
+
+    token_1_client.mint(&controller, &balances.get_unchecked(0));
+    token_2_client.mint(&controller, &balances.get_unchecked(1));
+
+    let pool = create_comet_pool(
+        e,
+        &controller,
+        &vec![e, token_1.clone(), token_2],
+        &vec![e, 5 * STROOP / 10, 5 * STROOP / 10],
+        &balances,
+        0_0030000,
+    );
+
+    (pool, controller, token_1)
+}
+
+#[test]
+fn test_set_freeze_status_emits_event() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.budget().reset_unlimited();
+
+    let (pool, controller, _) = create_pool(&e);
+    let comet = CometPoolContractClient::new(&e, &pool);
+
+    comet.set_freeze_status(&true);
+    let data = assert_pool_event(&e, &pool, symbol_short!("freeze"));
+    assert_eq!(
+        FreezeEvent::try_from_val(&e, &data).unwrap(),
+        FreezeEvent {
+            controller: controller.clone(),
+            frozen: true,
+        }
+    );
+
+    comet.set_freeze_status(&false);
+    let data = assert_pool_event(&e, &pool, symbol_short!("freeze"));
+    assert_eq!(
+        FreezeEvent::try_from_val(&e, &data).unwrap(),
+        FreezeEvent {
+            controller,
+            frozen: false,
+        }
+    );
+}
+
+#[test]
+fn test_gulp_emits_reserve_transition() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.budget().reset_unlimited();
+
+    let (pool, _, token) = create_pool(&e);
+    let comet = CometPoolContractClient::new(&e, &pool);
+    let token_client = MockTokenClient::new(&e, &token);
+    let previous_balance = comet.get_balance(&token);
+    let donation = 7 * STROOP;
+    token_client.mint(&pool, &donation);
+
+    comet.gulp(&token);
+
+    let new_balance = previous_balance + donation;
+    assert_eq!(comet.get_balance(&token), new_balance);
+    let data = assert_pool_event(&e, &pool, symbol_short!("gulp"));
+    assert_eq!(
+        GulpEvent::try_from_val(&e, &data).unwrap(),
+        GulpEvent {
+            token,
+            previous_balance,
+            new_balance,
+        }
+    );
+}

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod utils;
 pub mod c_num_test;
 pub mod c_pool_all;
 pub mod c_pool_dif_decimals;
+pub mod c_pool_events;
 pub mod c_pool_init;
 pub mod c_pool_join_exit;
 pub mod c_pool_single_sided;


### PR DESCRIPTION
## Summary

Pool freeze changes and `gulp` reserve updates were previously visible only through contract storage. This adds explicit events so monitoring systems and indexers can observe these state changes directly without changing the contract's public method signatures.

## Changes

- Add `FreezeEvent { controller, frozen }` and emit it after `set_freeze_status` successfully updates pool state.
- Add `GulpEvent { token, previous_balance, new_balance }` and emit it after `gulp` synchronizes the recorded reserve with the token contract balance.
- Add tests covering freeze, unfreeze, event topics, typed payloads, and gulp reserve transitions.

## Testing

- `cargo +1.78.0 test -p contracts` — 22 passed.
- `cargo fmt --all -- --check`.