### PR TITLE
Return structured contract errors for negative token amounts

### DIFF
--- a/contracts/src/c_pool/comet.rs
+++ b/contracts/src/c_pool/comet.rs
@@ -281,7 +281,7 @@ impl TokenInterface for CometPoolContract {
     fn approve(e: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
         from.require_auth();
 
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(&e, amount);
 
         e.storage()
             .instance()
@@ -304,7 +304,7 @@ impl TokenInterface for CometPoolContract {
     fn transfer(e: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
 
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(&e, amount);
 
         e.storage()
             .instance()
@@ -318,7 +318,7 @@ impl TokenInterface for CometPoolContract {
     fn transfer_from(e: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
 
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(&e, amount);
 
         e.storage()
             .instance()
@@ -332,8 +332,8 @@ impl TokenInterface for CometPoolContract {
 
     fn burn(e: Env, from: Address, amount: i128) {
         from.require_auth();
+        check_nonnegative_amount(&e, amount);
         let total = get_total_shares(&e);
-        check_nonnegative_amount(amount);
 
         e.storage()
             .instance()
@@ -346,8 +346,8 @@ impl TokenInterface for CometPoolContract {
 
     fn burn_from(e: Env, spender: Address, from: Address, amount: i128) {
         spender.require_auth();
+        check_nonnegative_amount(&e, amount);
         let total = get_total_shares(&e);
-        check_nonnegative_amount(amount);
 
         e.storage()
             .instance()

--- a/contracts/src/c_pool/token_utility.rs
+++ b/contracts/src/c_pool/token_utility.rs
@@ -1,9 +1,10 @@
 //! Utilities for the LP Token
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{assert_with_error, Address, Env};
 use soroban_token_sdk::TokenUtils;
 
 use super::{
     balance::{receive_balance, spend_balance},
+    error::Error,
     metadata::{get_total_shares, put_total_shares},
 };
 
@@ -29,16 +30,16 @@ pub fn push_underlying(e: &Env, token: &Address, to: &Address, amount: i128) {
 
 // Mint the given amount of LP Tokens
 pub fn mint_shares(e: &Env, to: &Address, amount: i128) {
+    check_nonnegative_amount(e, amount);
     let total = get_total_shares(e);
     put_total_shares(e, total + amount);
-    check_nonnegative_amount(amount);
     receive_balance(e, to.clone(), amount);
 }
 
 // Transfer the LP Tokens from the given 'from' Address to the contract Address
 pub fn pull_shares(e: &Env, from: &Address, amount: i128) {
     let contract_address = e.current_contract_address();
-    check_nonnegative_amount(amount);
+    check_nonnegative_amount(e, amount);
     spend_balance(e, from.clone(), amount);
     receive_balance(e, contract_address.clone(), amount);
     TokenUtils::new(e)
@@ -48,17 +49,15 @@ pub fn pull_shares(e: &Env, from: &Address, amount: i128) {
 
 // Burn the LP Tokens
 pub fn burn_shares(e: &Env, amount: i128) {
+    check_nonnegative_amount(e, amount);
     let total = get_total_shares(e);
     let contract_address = e.current_contract_address();
-    check_nonnegative_amount(amount);
     spend_balance(e, contract_address.clone(), amount);
     TokenUtils::new(e).events().burn(contract_address, amount);
     put_total_shares(e, total - amount);
 }
 
 // Check if the given amount is negative
-pub fn check_nonnegative_amount(amount: i128) {
-    if amount < 0 {
-        panic!("negative amount is not allowed: {}", amount)
-    }
+pub fn check_nonnegative_amount(e: &Env, amount: i128) {
+    assert_with_error!(e, amount >= 0, Error::ErrTokenAmountIsNegative);
 }

--- a/contracts/src/tests/c_pool_token_errors.rs
+++ b/contracts/src/tests/c_pool_token_errors.rs
@@ -1,0 +1,70 @@
+#![cfg(test)]
+
+use sep_41_token::testutils::MockTokenClient;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, Error, Vec};
+
+use crate::{
+    c_consts::STROOP,
+    c_pool::{comet::CometPoolContractClient, error::Error as CometError},
+    tests::utils::{create_comet_pool, create_stellar_token},
+};
+
+#[test]
+fn test_negative_token_amounts_return_contract_error() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.budget().reset_unlimited();
+
+    let controller = Address::generate(&e);
+    let spender = Address::generate(&e);
+    let recipient = Address::generate(&e);
+    let token_1 = create_stellar_token(&e, &controller);
+    let token_2 = create_stellar_token(&e, &controller);
+    let token_1_client = MockTokenClient::new(&e, &token_1);
+    let token_2_client = MockTokenClient::new(&e, &token_2);
+    let balances: Vec<i128> = vec![&e, 100 * STROOP, 100 * STROOP];
+
+    token_1_client.mint(&controller, &balances.get_unchecked(0));
+    token_2_client.mint(&controller, &balances.get_unchecked(1));
+
+    let pool = create_comet_pool(
+        &e,
+        &controller,
+        &vec![&e, token_1, token_2],
+        &vec![&e, 5 * STROOP / 10, 5 * STROOP / 10],
+        &balances,
+        0_0030000,
+    );
+    let comet = CometPoolContractClient::new(&e, &pool);
+    let negative_amount = -1;
+    let expected_error = Error::from_contract_error(CometError::ErrTokenAmountIsNegative as u32);
+
+    assert_eq!(
+        comet
+            .try_approve(&controller, &spender, &negative_amount, &100)
+            .err(),
+        Some(Ok(expected_error.clone()))
+    );
+    assert_eq!(
+        comet
+            .try_transfer(&controller, &recipient, &negative_amount)
+            .err(),
+        Some(Ok(expected_error.clone()))
+    );
+    assert_eq!(
+        comet
+            .try_transfer_from(&spender, &controller, &recipient, &negative_amount)
+            .err(),
+        Some(Ok(expected_error.clone()))
+    );
+    assert_eq!(
+        comet.try_burn(&controller, &negative_amount).err(),
+        Some(Ok(expected_error.clone()))
+    );
+    assert_eq!(
+        comet
+            .try_burn_from(&spender, &controller, &negative_amount)
+            .err(),
+        Some(Ok(expected_error))
+    );
+}

--- a/contracts/src/tests/mod.rs
+++ b/contracts/src/tests/mod.rs
@@ -9,3 +9,4 @@ pub mod c_pool_join_exit;
 pub mod c_pool_single_sided;
 pub mod c_pool_swap;
 pub mod c_pool_test;
+pub mod c_pool_token_errors;


### PR DESCRIPTION
## Summary

Negative SEP-41 token amounts previously triggered a generic Rust panic. This change returns the existing `ErrTokenAmountIsNegative` contract error instead, giving callers, simulations, and integrations a stable error code while preserving transaction rollback behavior.

## Changes

- Pass `Env` to `check_nonnegative_amount` and replace the generic panic with `ErrTokenAmountIsNegative` error code 25.
- Apply the structured validation consistently to `approve`, `transfer`, `transfer_from`, `burn`, `burn_from`, and internal LP mint, transfer, and burn helpers.
- Validate amounts before reading or updating LP supply accounting.
- Add tests confirming all five public SEP-41 mutation methods return error code 25 for negative amounts.

## Compatibility

Successful calls and public method signatures are unchanged. Only the failure response for negative token amounts changes from an unstructured panic to an existing structured contract error.

## Testing

- `cargo +1.78.0 test -p contracts` — 21 passed.
- `cargo fmt --all -- --check`.