### PR TITLE
Reject power approximations that do not converge within the iteration cap

### DIFF
--- a/contracts/src/c_num.rs
+++ b/contracts/src/c_num.rs
@@ -79,6 +79,7 @@ fn c_pow_approx(e: &Env, base: &I256, exp: &I256, precision: &I256, round_up: bo
     let mut term = bone.clone();
     let mut sum = term.clone();
     let prec = precision.clone();
+    let mut converged = false;
     // Capped to limit iterations in the event of a poor approximation
     // Max resource impact at 50 iterations:
     //  -> CPU: 5M inst
@@ -96,9 +97,12 @@ fn c_pow_approx(e: &Env, base: &I256, exp: &I256, precision: &I256, round_up: bo
             term.clone()
         };
         if abs_term <= prec {
+            converged = true;
             break;
         }
     }
+    assert_with_error!(e, converged, Error::ErrMathApprox);
+
     // the series has predicatable approximations bounds, so we can adjust the final sum by
     // the final term to (almost) ensure the sum is either an under or over estimate based
     // on the rounding direction.

--- a/contracts/src/tests/c_num_test.rs
+++ b/contracts/src/tests/c_num_test.rs
@@ -29,3 +29,15 @@ fn test_c_pow_high() {
         false,
     );
 }
+
+#[test]
+#[should_panic = "Error(Contract, #18)"]
+fn test_c_pow_rejects_unconverged_approximation() {
+    let env: Env = Env::default();
+    c_pow(
+        &env,
+        &I256::from_i128(&env, BONE / 100),
+        &I256::from_i128(&env, BONE / 5),
+        false,
+    );
+}

--- a/contracts/src/tests/c_pool_single_sided.rs
+++ b/contracts/src/tests/c_pool_single_sided.rs
@@ -288,8 +288,17 @@ fn test_single_sided_wdr() {
     let bal_token_out_fixed = bal_token_out.to_i128(&7);
     let under_out = bal_token_out_fixed - 1000;
 
-    // verify MAX_OUT_RATIO
+    // verify unconverged power approximation
     let result = comet.try_wdr_tokn_amt_in_get_lp_tokns_out(&token_1, &99_9999999, &0, &admin);
+    assert_eq!(
+        result.err(),
+        Some(Ok(Error::from_contract_error(
+            CometError::ErrMathApprox as u32
+        )))
+    );
+
+    // verify MAX_OUT_RATIO after a converged power approximation
+    let result = comet.try_wdr_tokn_amt_in_get_lp_tokns_out(&token_1, &(60 * STROOP), &0, &admin);
     assert_eq!(
         result.err(),
         Some(Ok(Error::from_contract_error(


### PR DESCRIPTION
## Summary

- Track whether `c_pow_approx` reaches `CPOW_PRECISION` within its existing 50-iteration cap.
- Return the structured `ErrMathApprox` contract error instead of using an unconverged partial sum.
- Add direct and public-entrypoint regression coverage while preserving `ErrMaxOutRatio` coverage for converged calculations.

## Rationale

The power approximation loop is capped at 50 iterations to bound resource use, but it previously continued with the partial sum when the final term still exceeded the requested precision. Extreme bases near the limits of the accepted range can reach that cap, so the accuracy and directional rounding of the result are not assured. Rejecting the calculation prevents pool accounting from using an approximation outside its precision requirement, and Soroban atomically rolls back the invocation.

## Behavior change

An extreme single-sided withdrawal that exhausts the approximation cap now returns `ErrMathApprox` instead of continuing far enough to return `ErrMaxOutRatio`. Normal operations and excessive withdrawals whose approximations converge retain their existing behavior.

## Testing

- `cargo +1.78.0 test --workspace --all-targets --locked` (21 pool tests and 1 factory test passed)
- Optimized pool and factory WASM builds
- `cargo fmt --all --check`
- `git diff --check`